### PR TITLE
Change the type of Size from int32 to float64

### DIFF
--- a/models/vm_volume_creation_params.go
+++ b/models/vm_volume_creation_params.go
@@ -37,7 +37,7 @@ type VMVolumeCreationParams struct {
 
 	// size
 	// Required: true
-	Size *int32 `json:"size"`
+	Size *float64 `json:"size"`
 }
 
 // Validate validates this Vm volume creation params


### PR DESCRIPTION
Change the type of Size for volume create from *int32 to *float64, or the max size of volume to be created will be only 2GB.