### PR TITLE
fix number type

### DIFF
--- a/models/application.go
+++ b/models/application.go
@@ -39,7 +39,7 @@ type Application struct {
 
 	// memory
 	// Required: true
-	Memory *float64 `json:"memory"`
+	Memory *int64 `json:"memory"`
 
 	// state
 	// Required: true
@@ -69,7 +69,7 @@ type Application struct {
 
 	// volume size
 	// Required: true
-	VolumeSize *float64 `json:"volume_size"`
+	VolumeSize *int64 `json:"volume_size"`
 }
 
 // Validate validates this application

--- a/models/application_where_input.go
+++ b/models/application_where_input.go
@@ -201,28 +201,28 @@ type ApplicationWhereInput struct {
 	LocalIDStartsWith *string `json:"local_id_starts_with,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// memory gt
-	MemoryGt *float64 `json:"memory_gt,omitempty"`
+	MemoryGt *int64 `json:"memory_gt,omitempty"`
 
 	// memory gte
-	MemoryGte *float64 `json:"memory_gte,omitempty"`
+	MemoryGte *int64 `json:"memory_gte,omitempty"`
 
 	// memory in
-	MemoryIn []float64 `json:"memory_in,omitempty"`
+	MemoryIn []int64 `json:"memory_in,omitempty"`
 
 	// memory lt
-	MemoryLt *float64 `json:"memory_lt,omitempty"`
+	MemoryLt *int64 `json:"memory_lt,omitempty"`
 
 	// memory lte
-	MemoryLte *float64 `json:"memory_lte,omitempty"`
+	MemoryLte *int64 `json:"memory_lte,omitempty"`
 
 	// memory not
-	MemoryNot *float64 `json:"memory_not,omitempty"`
+	MemoryNot *int64 `json:"memory_not,omitempty"`
 
 	// memory not in
-	MemoryNotIn []float64 `json:"memory_not_in,omitempty"`
+	MemoryNotIn []int64 `json:"memory_not_in,omitempty"`
 
 	// state
 	State *ApplicationState `json:"state,omitempty"`
@@ -384,28 +384,28 @@ type ApplicationWhereInput struct {
 	VM *VMWhereInput `json:"vm,omitempty"`
 
 	// volume size
-	VolumeSize *float64 `json:"volume_size,omitempty"`
+	VolumeSize *int64 `json:"volume_size,omitempty"`
 
 	// volume size gt
-	VolumeSizeGt *float64 `json:"volume_size_gt,omitempty"`
+	VolumeSizeGt *int64 `json:"volume_size_gt,omitempty"`
 
 	// volume size gte
-	VolumeSizeGte *float64 `json:"volume_size_gte,omitempty"`
+	VolumeSizeGte *int64 `json:"volume_size_gte,omitempty"`
 
 	// volume size in
-	VolumeSizeIn []float64 `json:"volume_size_in,omitempty"`
+	VolumeSizeIn []int64 `json:"volume_size_in,omitempty"`
 
 	// volume size lt
-	VolumeSizeLt *float64 `json:"volume_size_lt,omitempty"`
+	VolumeSizeLt *int64 `json:"volume_size_lt,omitempty"`
 
 	// volume size lte
-	VolumeSizeLte *float64 `json:"volume_size_lte,omitempty"`
+	VolumeSizeLte *int64 `json:"volume_size_lte,omitempty"`
 
 	// volume size not
-	VolumeSizeNot *float64 `json:"volume_size_not,omitempty"`
+	VolumeSizeNot *int64 `json:"volume_size_not,omitempty"`
 
 	// volume size not in
-	VolumeSizeNotIn []float64 `json:"volume_size_not_in,omitempty"`
+	VolumeSizeNotIn []int64 `json:"volume_size_not_in,omitempty"`
 }
 
 // Validate validates this application where input

--- a/models/backup_license.go
+++ b/models/backup_license.go
@@ -36,7 +36,7 @@ type BackupLicense struct {
 
 	// max capacity
 	// Required: true
-	MaxCapacity *float64 `json:"max_capacity"`
+	MaxCapacity *int64 `json:"max_capacity"`
 
 	// sign date
 	// Required: true

--- a/models/backup_license_where_input.go
+++ b/models/backup_license_where_input.go
@@ -150,28 +150,28 @@ type BackupLicenseWhereInput struct {
 	LicenseSerialStartsWith *string `json:"license_serial_starts_with,omitempty"`
 
 	// max capacity
-	MaxCapacity *float64 `json:"max_capacity,omitempty"`
+	MaxCapacity *int64 `json:"max_capacity,omitempty"`
 
 	// max capacity gt
-	MaxCapacityGt *float64 `json:"max_capacity_gt,omitempty"`
+	MaxCapacityGt *int64 `json:"max_capacity_gt,omitempty"`
 
 	// max capacity gte
-	MaxCapacityGte *float64 `json:"max_capacity_gte,omitempty"`
+	MaxCapacityGte *int64 `json:"max_capacity_gte,omitempty"`
 
 	// max capacity in
-	MaxCapacityIn []float64 `json:"max_capacity_in,omitempty"`
+	MaxCapacityIn []int64 `json:"max_capacity_in,omitempty"`
 
 	// max capacity lt
-	MaxCapacityLt *float64 `json:"max_capacity_lt,omitempty"`
+	MaxCapacityLt *int64 `json:"max_capacity_lt,omitempty"`
 
 	// max capacity lte
-	MaxCapacityLte *float64 `json:"max_capacity_lte,omitempty"`
+	MaxCapacityLte *int64 `json:"max_capacity_lte,omitempty"`
 
 	// max capacity not
-	MaxCapacityNot *float64 `json:"max_capacity_not,omitempty"`
+	MaxCapacityNot *int64 `json:"max_capacity_not,omitempty"`
 
 	// max capacity not in
-	MaxCapacityNotIn []float64 `json:"max_capacity_not_in,omitempty"`
+	MaxCapacityNotIn []int64 `json:"max_capacity_not_in,omitempty"`
 
 	// sign date
 	SignDate *string `json:"sign_date,omitempty"`

--- a/models/backup_package.go
+++ b/models/backup_package.go
@@ -48,7 +48,7 @@ type BackupPackage struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// version
 	// Required: true

--- a/models/backup_package_where_input.go
+++ b/models/backup_package_where_input.go
@@ -204,28 +204,28 @@ type BackupPackageWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// version
 	Version *string `json:"version,omitempty"`

--- a/models/backup_plan.go
+++ b/models/backup_plan.go
@@ -41,7 +41,7 @@ type BackupPlan struct {
 	BackupStoreRepository *NestedBackupStoreRepository `json:"backup_store_repository"`
 
 	// backup total size
-	BackupTotalSize *float64 `json:"backup_total_size,omitempty"`
+	BackupTotalSize *int64 `json:"backup_total_size,omitempty"`
 
 	// compression
 	Compression *bool `json:"compression,omitempty"`

--- a/models/backup_plan_where_input.go
+++ b/models/backup_plan_where_input.go
@@ -90,28 +90,28 @@ type BackupPlanWhereInput struct {
 	BackupStoreRepository *BackupStoreRepositoryWhereInput `json:"backup_store_repository,omitempty"`
 
 	// backup total size
-	BackupTotalSize *float64 `json:"backup_total_size,omitempty"`
+	BackupTotalSize *int64 `json:"backup_total_size,omitempty"`
 
 	// backup total size gt
-	BackupTotalSizeGt *float64 `json:"backup_total_size_gt,omitempty"`
+	BackupTotalSizeGt *int64 `json:"backup_total_size_gt,omitempty"`
 
 	// backup total size gte
-	BackupTotalSizeGte *float64 `json:"backup_total_size_gte,omitempty"`
+	BackupTotalSizeGte *int64 `json:"backup_total_size_gte,omitempty"`
 
 	// backup total size in
-	BackupTotalSizeIn []float64 `json:"backup_total_size_in,omitempty"`
+	BackupTotalSizeIn []int64 `json:"backup_total_size_in,omitempty"`
 
 	// backup total size lt
-	BackupTotalSizeLt *float64 `json:"backup_total_size_lt,omitempty"`
+	BackupTotalSizeLt *int64 `json:"backup_total_size_lt,omitempty"`
 
 	// backup total size lte
-	BackupTotalSizeLte *float64 `json:"backup_total_size_lte,omitempty"`
+	BackupTotalSizeLte *int64 `json:"backup_total_size_lte,omitempty"`
 
 	// backup total size not
-	BackupTotalSizeNot *float64 `json:"backup_total_size_not,omitempty"`
+	BackupTotalSizeNot *int64 `json:"backup_total_size_not,omitempty"`
 
 	// backup total size not in
-	BackupTotalSizeNotIn []float64 `json:"backup_total_size_not_in,omitempty"`
+	BackupTotalSizeNotIn []int64 `json:"backup_total_size_not_in,omitempty"`
 
 	// compression
 	Compression *bool `json:"compression,omitempty"`

--- a/models/backup_restore_execution.go
+++ b/models/backup_restore_execution.go
@@ -46,7 +46,7 @@ type BackupRestoreExecution struct {
 	Name *string `json:"name"`
 
 	// read bytes
-	ReadBytes *float64 `json:"read_bytes,omitempty"`
+	ReadBytes *int64 `json:"read_bytes,omitempty"`
 
 	// rebuild name
 	RebuildName *string `json:"rebuild_name,omitempty"`
@@ -70,7 +70,7 @@ type BackupRestoreExecution struct {
 	Status *BackupExecutionStatus `json:"status"`
 
 	// total bytes
-	TotalBytes *float64 `json:"total_bytes,omitempty"`
+	TotalBytes *int64 `json:"total_bytes,omitempty"`
 }
 
 // Validate validates this backup restore execution

--- a/models/backup_restore_execution_where_input.go
+++ b/models/backup_restore_execution_where_input.go
@@ -189,28 +189,28 @@ type BackupRestoreExecutionWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// read bytes
-	ReadBytes *float64 `json:"read_bytes,omitempty"`
+	ReadBytes *int64 `json:"read_bytes,omitempty"`
 
 	// read bytes gt
-	ReadBytesGt *float64 `json:"read_bytes_gt,omitempty"`
+	ReadBytesGt *int64 `json:"read_bytes_gt,omitempty"`
 
 	// read bytes gte
-	ReadBytesGte *float64 `json:"read_bytes_gte,omitempty"`
+	ReadBytesGte *int64 `json:"read_bytes_gte,omitempty"`
 
 	// read bytes in
-	ReadBytesIn []float64 `json:"read_bytes_in,omitempty"`
+	ReadBytesIn []int64 `json:"read_bytes_in,omitempty"`
 
 	// read bytes lt
-	ReadBytesLt *float64 `json:"read_bytes_lt,omitempty"`
+	ReadBytesLt *int64 `json:"read_bytes_lt,omitempty"`
 
 	// read bytes lte
-	ReadBytesLte *float64 `json:"read_bytes_lte,omitempty"`
+	ReadBytesLte *int64 `json:"read_bytes_lte,omitempty"`
 
 	// read bytes not
-	ReadBytesNot *float64 `json:"read_bytes_not,omitempty"`
+	ReadBytesNot *int64 `json:"read_bytes_not,omitempty"`
 
 	// read bytes not in
-	ReadBytesNotIn []float64 `json:"read_bytes_not_in,omitempty"`
+	ReadBytesNotIn []int64 `json:"read_bytes_not_in,omitempty"`
 
 	// rebuild name
 	RebuildName *string `json:"rebuild_name,omitempty"`
@@ -300,28 +300,28 @@ type BackupRestoreExecutionWhereInput struct {
 	StatusNotIn []BackupExecutionStatus `json:"status_not_in,omitempty"`
 
 	// total bytes
-	TotalBytes *float64 `json:"total_bytes,omitempty"`
+	TotalBytes *int64 `json:"total_bytes,omitempty"`
 
 	// total bytes gt
-	TotalBytesGt *float64 `json:"total_bytes_gt,omitempty"`
+	TotalBytesGt *int64 `json:"total_bytes_gt,omitempty"`
 
 	// total bytes gte
-	TotalBytesGte *float64 `json:"total_bytes_gte,omitempty"`
+	TotalBytesGte *int64 `json:"total_bytes_gte,omitempty"`
 
 	// total bytes in
-	TotalBytesIn []float64 `json:"total_bytes_in,omitempty"`
+	TotalBytesIn []int64 `json:"total_bytes_in,omitempty"`
 
 	// total bytes lt
-	TotalBytesLt *float64 `json:"total_bytes_lt,omitempty"`
+	TotalBytesLt *int64 `json:"total_bytes_lt,omitempty"`
 
 	// total bytes lte
-	TotalBytesLte *float64 `json:"total_bytes_lte,omitempty"`
+	TotalBytesLte *int64 `json:"total_bytes_lte,omitempty"`
 
 	// total bytes not
-	TotalBytesNot *float64 `json:"total_bytes_not,omitempty"`
+	TotalBytesNot *int64 `json:"total_bytes_not,omitempty"`
 
 	// total bytes not in
-	TotalBytesNotIn []float64 `json:"total_bytes_not_in,omitempty"`
+	TotalBytesNotIn []int64 `json:"total_bytes_not_in,omitempty"`
 }
 
 // Validate validates this backup restore execution where input

--- a/models/backup_restore_point.go
+++ b/models/backup_restore_point.go
@@ -59,16 +59,16 @@ type BackupRestorePoint struct {
 	LocalID *string `json:"local_id"`
 
 	// logical size
-	LogicalSize *float64 `json:"logical_size,omitempty"`
+	LogicalSize *int64 `json:"logical_size,omitempty"`
 
 	// parent restore point
 	ParentRestorePoint *string `json:"parent_restore_point,omitempty"`
 
 	// physical size
-	PhysicalSize *float64 `json:"physical_size,omitempty"`
+	PhysicalSize *int64 `json:"physical_size,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// slice
 	// Required: true
@@ -78,10 +78,10 @@ type BackupRestorePoint struct {
 	Type *BackupRestorePointType `json:"type,omitempty"`
 
 	// valid capacity
-	ValidCapacity *float64 `json:"valid_capacity,omitempty"`
+	ValidCapacity *int64 `json:"valid_capacity,omitempty"`
 
 	// valid size
-	ValidSize *float64 `json:"valid_size,omitempty"`
+	ValidSize *int64 `json:"valid_size,omitempty"`
 
 	// vm
 	VM *NestedVM `json:"vm,omitempty"`

--- a/models/backup_restore_point_where_input.go
+++ b/models/backup_restore_point_where_input.go
@@ -240,28 +240,28 @@ type BackupRestorePointWhereInput struct {
 	LocalIDStartsWith *string `json:"local_id_starts_with,omitempty"`
 
 	// logical size
-	LogicalSize *float64 `json:"logical_size,omitempty"`
+	LogicalSize *int64 `json:"logical_size,omitempty"`
 
 	// logical size gt
-	LogicalSizeGt *float64 `json:"logical_size_gt,omitempty"`
+	LogicalSizeGt *int64 `json:"logical_size_gt,omitempty"`
 
 	// logical size gte
-	LogicalSizeGte *float64 `json:"logical_size_gte,omitempty"`
+	LogicalSizeGte *int64 `json:"logical_size_gte,omitempty"`
 
 	// logical size in
-	LogicalSizeIn []float64 `json:"logical_size_in,omitempty"`
+	LogicalSizeIn []int64 `json:"logical_size_in,omitempty"`
 
 	// logical size lt
-	LogicalSizeLt *float64 `json:"logical_size_lt,omitempty"`
+	LogicalSizeLt *int64 `json:"logical_size_lt,omitempty"`
 
 	// logical size lte
-	LogicalSizeLte *float64 `json:"logical_size_lte,omitempty"`
+	LogicalSizeLte *int64 `json:"logical_size_lte,omitempty"`
 
 	// logical size not
-	LogicalSizeNot *float64 `json:"logical_size_not,omitempty"`
+	LogicalSizeNot *int64 `json:"logical_size_not,omitempty"`
 
 	// logical size not in
-	LogicalSizeNotIn []float64 `json:"logical_size_not_in,omitempty"`
+	LogicalSizeNotIn []int64 `json:"logical_size_not_in,omitempty"`
 
 	// parent restore point
 	ParentRestorePoint *string `json:"parent_restore_point,omitempty"`
@@ -306,28 +306,28 @@ type BackupRestorePointWhereInput struct {
 	ParentRestorePointStartsWith *string `json:"parent_restore_point_starts_with,omitempty"`
 
 	// physical size
-	PhysicalSize *float64 `json:"physical_size,omitempty"`
+	PhysicalSize *int64 `json:"physical_size,omitempty"`
 
 	// physical size gt
-	PhysicalSizeGt *float64 `json:"physical_size_gt,omitempty"`
+	PhysicalSizeGt *int64 `json:"physical_size_gt,omitempty"`
 
 	// physical size gte
-	PhysicalSizeGte *float64 `json:"physical_size_gte,omitempty"`
+	PhysicalSizeGte *int64 `json:"physical_size_gte,omitempty"`
 
 	// physical size in
-	PhysicalSizeIn []float64 `json:"physical_size_in,omitempty"`
+	PhysicalSizeIn []int64 `json:"physical_size_in,omitempty"`
 
 	// physical size lt
-	PhysicalSizeLt *float64 `json:"physical_size_lt,omitempty"`
+	PhysicalSizeLt *int64 `json:"physical_size_lt,omitempty"`
 
 	// physical size lte
-	PhysicalSizeLte *float64 `json:"physical_size_lte,omitempty"`
+	PhysicalSizeLte *int64 `json:"physical_size_lte,omitempty"`
 
 	// physical size not
-	PhysicalSizeNot *float64 `json:"physical_size_not,omitempty"`
+	PhysicalSizeNot *int64 `json:"physical_size_not,omitempty"`
 
 	// physical size not in
-	PhysicalSizeNotIn []float64 `json:"physical_size_not_in,omitempty"`
+	PhysicalSizeNotIn []int64 `json:"physical_size_not_in,omitempty"`
 
 	// resource version gt
 	ResourceVersionGt *int32 `json:"resource_version_gt,omitempty"`
@@ -351,28 +351,28 @@ type BackupRestorePointWhereInput struct {
 	ResourceVersionNotIn []int32 `json:"resource_version_not_in,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// slice
 	Slice *string `json:"slice,omitempty"`
@@ -429,52 +429,52 @@ type BackupRestorePointWhereInput struct {
 	TypeNotIn []BackupRestorePointType `json:"type_not_in,omitempty"`
 
 	// valid capacity
-	ValidCapacity *float64 `json:"valid_capacity,omitempty"`
+	ValidCapacity *int64 `json:"valid_capacity,omitempty"`
 
 	// valid capacity gt
-	ValidCapacityGt *float64 `json:"valid_capacity_gt,omitempty"`
+	ValidCapacityGt *int64 `json:"valid_capacity_gt,omitempty"`
 
 	// valid capacity gte
-	ValidCapacityGte *float64 `json:"valid_capacity_gte,omitempty"`
+	ValidCapacityGte *int64 `json:"valid_capacity_gte,omitempty"`
 
 	// valid capacity in
-	ValidCapacityIn []float64 `json:"valid_capacity_in,omitempty"`
+	ValidCapacityIn []int64 `json:"valid_capacity_in,omitempty"`
 
 	// valid capacity lt
-	ValidCapacityLt *float64 `json:"valid_capacity_lt,omitempty"`
+	ValidCapacityLt *int64 `json:"valid_capacity_lt,omitempty"`
 
 	// valid capacity lte
-	ValidCapacityLte *float64 `json:"valid_capacity_lte,omitempty"`
+	ValidCapacityLte *int64 `json:"valid_capacity_lte,omitempty"`
 
 	// valid capacity not
-	ValidCapacityNot *float64 `json:"valid_capacity_not,omitempty"`
+	ValidCapacityNot *int64 `json:"valid_capacity_not,omitempty"`
 
 	// valid capacity not in
-	ValidCapacityNotIn []float64 `json:"valid_capacity_not_in,omitempty"`
+	ValidCapacityNotIn []int64 `json:"valid_capacity_not_in,omitempty"`
 
 	// valid size
-	ValidSize *float64 `json:"valid_size,omitempty"`
+	ValidSize *int64 `json:"valid_size,omitempty"`
 
 	// valid size gt
-	ValidSizeGt *float64 `json:"valid_size_gt,omitempty"`
+	ValidSizeGt *int64 `json:"valid_size_gt,omitempty"`
 
 	// valid size gte
-	ValidSizeGte *float64 `json:"valid_size_gte,omitempty"`
+	ValidSizeGte *int64 `json:"valid_size_gte,omitempty"`
 
 	// valid size in
-	ValidSizeIn []float64 `json:"valid_size_in,omitempty"`
+	ValidSizeIn []int64 `json:"valid_size_in,omitempty"`
 
 	// valid size lt
-	ValidSizeLt *float64 `json:"valid_size_lt,omitempty"`
+	ValidSizeLt *int64 `json:"valid_size_lt,omitempty"`
 
 	// valid size lte
-	ValidSizeLte *float64 `json:"valid_size_lte,omitempty"`
+	ValidSizeLte *int64 `json:"valid_size_lte,omitempty"`
 
 	// valid size not
-	ValidSizeNot *float64 `json:"valid_size_not,omitempty"`
+	ValidSizeNot *int64 `json:"valid_size_not,omitempty"`
 
 	// valid size not in
-	ValidSizeNotIn []float64 `json:"valid_size_not_in,omitempty"`
+	ValidSizeNotIn []int64 `json:"valid_size_not_in,omitempty"`
 
 	// vm
 	VM *VMWhereInput `json:"vm,omitempty"`

--- a/models/backup_store_repository.go
+++ b/models/backup_store_repository.go
@@ -73,7 +73,7 @@ type BackupStoreRepository struct {
 
 	// total capacity
 	// Required: true
-	TotalCapacity *float64 `json:"total_capacity"`
+	TotalCapacity *int64 `json:"total_capacity"`
 
 	// type
 	// Required: true
@@ -81,10 +81,10 @@ type BackupStoreRepository struct {
 
 	// used data space
 	// Required: true
-	UsedDataSpace *float64 `json:"used_data_space"`
+	UsedDataSpace *int64 `json:"used_data_space"`
 
 	// valid data space
-	ValidDataSpace *float64 `json:"valid_data_space,omitempty"`
+	ValidDataSpace *int64 `json:"valid_data_space,omitempty"`
 }
 
 // Validate validates this backup store repository

--- a/models/backup_store_repository_where_input.go
+++ b/models/backup_store_repository_where_input.go
@@ -540,28 +540,28 @@ type BackupStoreRepositoryWhereInput struct {
 	StatusNotIn []BackupStoreStatus `json:"status_not_in,omitempty"`
 
 	// total capacity
-	TotalCapacity *float64 `json:"total_capacity,omitempty"`
+	TotalCapacity *int64 `json:"total_capacity,omitempty"`
 
 	// total capacity gt
-	TotalCapacityGt *float64 `json:"total_capacity_gt,omitempty"`
+	TotalCapacityGt *int64 `json:"total_capacity_gt,omitempty"`
 
 	// total capacity gte
-	TotalCapacityGte *float64 `json:"total_capacity_gte,omitempty"`
+	TotalCapacityGte *int64 `json:"total_capacity_gte,omitempty"`
 
 	// total capacity in
-	TotalCapacityIn []float64 `json:"total_capacity_in,omitempty"`
+	TotalCapacityIn []int64 `json:"total_capacity_in,omitempty"`
 
 	// total capacity lt
-	TotalCapacityLt *float64 `json:"total_capacity_lt,omitempty"`
+	TotalCapacityLt *int64 `json:"total_capacity_lt,omitempty"`
 
 	// total capacity lte
-	TotalCapacityLte *float64 `json:"total_capacity_lte,omitempty"`
+	TotalCapacityLte *int64 `json:"total_capacity_lte,omitempty"`
 
 	// total capacity not
-	TotalCapacityNot *float64 `json:"total_capacity_not,omitempty"`
+	TotalCapacityNot *int64 `json:"total_capacity_not,omitempty"`
 
 	// total capacity not in
-	TotalCapacityNotIn []float64 `json:"total_capacity_not_in,omitempty"`
+	TotalCapacityNotIn []int64 `json:"total_capacity_not_in,omitempty"`
 
 	// type
 	Type *BackupStoreType `json:"type,omitempty"`
@@ -576,52 +576,52 @@ type BackupStoreRepositoryWhereInput struct {
 	TypeNotIn []BackupStoreType `json:"type_not_in,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// used data space gt
-	UsedDataSpaceGt *float64 `json:"used_data_space_gt,omitempty"`
+	UsedDataSpaceGt *int64 `json:"used_data_space_gt,omitempty"`
 
 	// used data space gte
-	UsedDataSpaceGte *float64 `json:"used_data_space_gte,omitempty"`
+	UsedDataSpaceGte *int64 `json:"used_data_space_gte,omitempty"`
 
 	// used data space in
-	UsedDataSpaceIn []float64 `json:"used_data_space_in,omitempty"`
+	UsedDataSpaceIn []int64 `json:"used_data_space_in,omitempty"`
 
 	// used data space lt
-	UsedDataSpaceLt *float64 `json:"used_data_space_lt,omitempty"`
+	UsedDataSpaceLt *int64 `json:"used_data_space_lt,omitempty"`
 
 	// used data space lte
-	UsedDataSpaceLte *float64 `json:"used_data_space_lte,omitempty"`
+	UsedDataSpaceLte *int64 `json:"used_data_space_lte,omitempty"`
 
 	// used data space not
-	UsedDataSpaceNot *float64 `json:"used_data_space_not,omitempty"`
+	UsedDataSpaceNot *int64 `json:"used_data_space_not,omitempty"`
 
 	// used data space not in
-	UsedDataSpaceNotIn []float64 `json:"used_data_space_not_in,omitempty"`
+	UsedDataSpaceNotIn []int64 `json:"used_data_space_not_in,omitempty"`
 
 	// valid data space
-	ValidDataSpace *float64 `json:"valid_data_space,omitempty"`
+	ValidDataSpace *int64 `json:"valid_data_space,omitempty"`
 
 	// valid data space gt
-	ValidDataSpaceGt *float64 `json:"valid_data_space_gt,omitempty"`
+	ValidDataSpaceGt *int64 `json:"valid_data_space_gt,omitempty"`
 
 	// valid data space gte
-	ValidDataSpaceGte *float64 `json:"valid_data_space_gte,omitempty"`
+	ValidDataSpaceGte *int64 `json:"valid_data_space_gte,omitempty"`
 
 	// valid data space in
-	ValidDataSpaceIn []float64 `json:"valid_data_space_in,omitempty"`
+	ValidDataSpaceIn []int64 `json:"valid_data_space_in,omitempty"`
 
 	// valid data space lt
-	ValidDataSpaceLt *float64 `json:"valid_data_space_lt,omitempty"`
+	ValidDataSpaceLt *int64 `json:"valid_data_space_lt,omitempty"`
 
 	// valid data space lte
-	ValidDataSpaceLte *float64 `json:"valid_data_space_lte,omitempty"`
+	ValidDataSpaceLte *int64 `json:"valid_data_space_lte,omitempty"`
 
 	// valid data space not
-	ValidDataSpaceNot *float64 `json:"valid_data_space_not,omitempty"`
+	ValidDataSpaceNot *int64 `json:"valid_data_space_not,omitempty"`
 
 	// valid data space not in
-	ValidDataSpaceNotIn []float64 `json:"valid_data_space_not_in,omitempty"`
+	ValidDataSpaceNotIn []int64 `json:"valid_data_space_not_in,omitempty"`
 }
 
 // Validate validates this backup store repository where input

--- a/models/backup_target_execution.go
+++ b/models/backup_target_execution.go
@@ -55,13 +55,13 @@ type BackupTargetExecution struct {
 	ParentBackup *string `json:"parent_backup"`
 
 	// read bytes
-	ReadBytes *float64 `json:"read_bytes,omitempty"`
+	ReadBytes *int64 `json:"read_bytes,omitempty"`
 
 	// status
 	Status *BackupExecutionStatus `json:"status,omitempty"`
 
 	// total bytes
-	TotalBytes *float64 `json:"total_bytes,omitempty"`
+	TotalBytes *int64 `json:"total_bytes,omitempty"`
 
 	// type
 	// Required: true

--- a/models/backup_target_execution_where_input.go
+++ b/models/backup_target_execution_where_input.go
@@ -306,28 +306,28 @@ type BackupTargetExecutionWhereInput struct {
 	ParentBackupStartsWith *string `json:"parent_backup_starts_with,omitempty"`
 
 	// read bytes
-	ReadBytes *float64 `json:"read_bytes,omitempty"`
+	ReadBytes *int64 `json:"read_bytes,omitempty"`
 
 	// read bytes gt
-	ReadBytesGt *float64 `json:"read_bytes_gt,omitempty"`
+	ReadBytesGt *int64 `json:"read_bytes_gt,omitempty"`
 
 	// read bytes gte
-	ReadBytesGte *float64 `json:"read_bytes_gte,omitempty"`
+	ReadBytesGte *int64 `json:"read_bytes_gte,omitempty"`
 
 	// read bytes in
-	ReadBytesIn []float64 `json:"read_bytes_in,omitempty"`
+	ReadBytesIn []int64 `json:"read_bytes_in,omitempty"`
 
 	// read bytes lt
-	ReadBytesLt *float64 `json:"read_bytes_lt,omitempty"`
+	ReadBytesLt *int64 `json:"read_bytes_lt,omitempty"`
 
 	// read bytes lte
-	ReadBytesLte *float64 `json:"read_bytes_lte,omitempty"`
+	ReadBytesLte *int64 `json:"read_bytes_lte,omitempty"`
 
 	// read bytes not
-	ReadBytesNot *float64 `json:"read_bytes_not,omitempty"`
+	ReadBytesNot *int64 `json:"read_bytes_not,omitempty"`
 
 	// read bytes not in
-	ReadBytesNotIn []float64 `json:"read_bytes_not_in,omitempty"`
+	ReadBytesNotIn []int64 `json:"read_bytes_not_in,omitempty"`
 
 	// resource version gt
 	ResourceVersionGt *int32 `json:"resource_version_gt,omitempty"`
@@ -363,28 +363,28 @@ type BackupTargetExecutionWhereInput struct {
 	StatusNotIn []BackupExecutionStatus `json:"status_not_in,omitempty"`
 
 	// total bytes
-	TotalBytes *float64 `json:"total_bytes,omitempty"`
+	TotalBytes *int64 `json:"total_bytes,omitempty"`
 
 	// total bytes gt
-	TotalBytesGt *float64 `json:"total_bytes_gt,omitempty"`
+	TotalBytesGt *int64 `json:"total_bytes_gt,omitempty"`
 
 	// total bytes gte
-	TotalBytesGte *float64 `json:"total_bytes_gte,omitempty"`
+	TotalBytesGte *int64 `json:"total_bytes_gte,omitempty"`
 
 	// total bytes in
-	TotalBytesIn []float64 `json:"total_bytes_in,omitempty"`
+	TotalBytesIn []int64 `json:"total_bytes_in,omitempty"`
 
 	// total bytes lt
-	TotalBytesLt *float64 `json:"total_bytes_lt,omitempty"`
+	TotalBytesLt *int64 `json:"total_bytes_lt,omitempty"`
 
 	// total bytes lte
-	TotalBytesLte *float64 `json:"total_bytes_lte,omitempty"`
+	TotalBytesLte *int64 `json:"total_bytes_lte,omitempty"`
 
 	// total bytes not
-	TotalBytesNot *float64 `json:"total_bytes_not,omitempty"`
+	TotalBytesNot *int64 `json:"total_bytes_not,omitempty"`
 
 	// total bytes not in
-	TotalBytesNotIn []float64 `json:"total_bytes_not_in,omitempty"`
+	TotalBytesNotIn []int64 `json:"total_bytes_not_in,omitempty"`
 
 	// type
 	Type *BackupExecutionType `json:"type,omitempty"`

--- a/models/cluster.go
+++ b/models/cluster.go
@@ -63,7 +63,7 @@ type Cluster struct {
 	EverouteCluster *NestedEverouteCluster `json:"everoute_cluster,omitempty"`
 
 	// failure data space
-	FailureDataSpace *float64 `json:"failure_data_space,omitempty"`
+	FailureDataSpace *int64 `json:"failure_data_space,omitempty"`
 
 	// has metrox
 	HasMetrox *bool `json:"has_metrox,omitempty"`
@@ -125,10 +125,10 @@ type Cluster struct {
 	MaxChunkNum *int32 `json:"max_chunk_num,omitempty"`
 
 	// max physical data capacity
-	MaxPhysicalDataCapacity *float64 `json:"max_physical_data_capacity,omitempty"`
+	MaxPhysicalDataCapacity *int64 `json:"max_physical_data_capacity,omitempty"`
 
 	// max physical data capacity per node
-	MaxPhysicalDataCapacityPerNode *float64 `json:"max_physical_data_capacity_per_node,omitempty"`
+	MaxPhysicalDataCapacityPerNode *int64 `json:"max_physical_data_capacity_per_node,omitempty"`
 
 	// metro availability checklist
 	MetroAvailabilityChecklist *NestedMetroAvailabilityChecklist `json:"metro_availability_checklist,omitempty"`
@@ -140,10 +140,10 @@ type Cluster struct {
 	MgtNetmask *string `json:"mgt_netmask,omitempty"`
 
 	// migration data size
-	MigrationDataSize *float64 `json:"migration_data_size,omitempty"`
+	MigrationDataSize *int64 `json:"migration_data_size,omitempty"`
 
 	// migration speed
-	MigrationSpeed *float64 `json:"migration_speed,omitempty"`
+	MigrationSpeed *int64 `json:"migration_speed,omitempty"`
 
 	// name
 	// Required: true
@@ -172,7 +172,7 @@ type Cluster struct {
 	ProvisionedForActiveVMRatio *float64 `json:"provisioned_for_active_vm_ratio,omitempty"`
 
 	// provisioned memory bytes
-	ProvisionedMemoryBytes *float64 `json:"provisioned_memory_bytes,omitempty"`
+	ProvisionedMemoryBytes *int64 `json:"provisioned_memory_bytes,omitempty"`
 
 	// provisioned ratio
 	ProvisionedRatio *float64 `json:"provisioned_ratio,omitempty"`
@@ -185,10 +185,10 @@ type Cluster struct {
 	RecommendedCPUModels []string `json:"recommended_cpu_models"`
 
 	// recover data size
-	RecoverDataSize *float64 `json:"recover_data_size,omitempty"`
+	RecoverDataSize *int64 `json:"recover_data_size,omitempty"`
 
 	// recover speed
-	RecoverSpeed *float64 `json:"recover_speed,omitempty"`
+	RecoverSpeed *int64 `json:"recover_speed,omitempty"`
 
 	// reserved cpu cores for system service
 	ReservedCPUCoresForSystemService *int32 `json:"reserved_cpu_cores_for_system_service,omitempty"`
@@ -212,13 +212,13 @@ type Cluster struct {
 	SuspendedVMNum *int32 `json:"suspended_vm_num,omitempty"`
 
 	// total cache capacity
-	TotalCacheCapacity *float64 `json:"total_cache_capacity,omitempty"`
+	TotalCacheCapacity *int64 `json:"total_cache_capacity,omitempty"`
 
 	// total cpu cores
 	TotalCPUCores *int32 `json:"total_cpu_cores,omitempty"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total cpu models
 	// Required: true
@@ -228,10 +228,10 @@ type Cluster struct {
 	TotalCPUSockets *int32 `json:"total_cpu_sockets,omitempty"`
 
 	// total data capacity
-	TotalDataCapacity *float64 `json:"total_data_capacity,omitempty"`
+	TotalDataCapacity *int64 `json:"total_data_capacity,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// type
 	// Required: true
@@ -241,16 +241,16 @@ type Cluster struct {
 	UpgradeToolVersion *string `json:"upgrade_tool_version,omitempty"`
 
 	// used cpu hz
-	UsedCPUHz *float64 `json:"used_cpu_hz,omitempty"`
+	UsedCPUHz *int64 `json:"used_cpu_hz,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// used memory bytes
-	UsedMemoryBytes *float64 `json:"used_memory_bytes,omitempty"`
+	UsedMemoryBytes *int64 `json:"used_memory_bytes,omitempty"`
 
 	// valid data space
-	ValidDataSpace *float64 `json:"valid_data_space,omitempty"`
+	ValidDataSpace *int64 `json:"valid_data_space,omitempty"`
 
 	// vcenter account
 	VcenterAccount *NestedVcenterAccount `json:"vcenterAccount,omitempty"`

--- a/models/cluster_image.go
+++ b/models/cluster_image.go
@@ -36,7 +36,7 @@ type ClusterImage struct {
 
 	// meta size
 	// Required: true
-	MetaSize *float64 `json:"meta_size"`
+	MetaSize *int64 `json:"meta_size"`
 
 	// name
 	// Required: true
@@ -44,7 +44,7 @@ type ClusterImage struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// upgrade from
 	// Required: true

--- a/models/cluster_image_where_input.go
+++ b/models/cluster_image_where_input.go
@@ -129,28 +129,28 @@ type ClusterImageWhereInput struct {
 	MetaNameStartsWith *string `json:"meta_name_starts_with,omitempty"`
 
 	// meta size
-	MetaSize *float64 `json:"meta_size,omitempty"`
+	MetaSize *int64 `json:"meta_size,omitempty"`
 
 	// meta size gt
-	MetaSizeGt *float64 `json:"meta_size_gt,omitempty"`
+	MetaSizeGt *int64 `json:"meta_size_gt,omitempty"`
 
 	// meta size gte
-	MetaSizeGte *float64 `json:"meta_size_gte,omitempty"`
+	MetaSizeGte *int64 `json:"meta_size_gte,omitempty"`
 
 	// meta size in
-	MetaSizeIn []float64 `json:"meta_size_in,omitempty"`
+	MetaSizeIn []int64 `json:"meta_size_in,omitempty"`
 
 	// meta size lt
-	MetaSizeLt *float64 `json:"meta_size_lt,omitempty"`
+	MetaSizeLt *int64 `json:"meta_size_lt,omitempty"`
 
 	// meta size lte
-	MetaSizeLte *float64 `json:"meta_size_lte,omitempty"`
+	MetaSizeLte *int64 `json:"meta_size_lte,omitempty"`
 
 	// meta size not
-	MetaSizeNot *float64 `json:"meta_size_not,omitempty"`
+	MetaSizeNot *int64 `json:"meta_size_not,omitempty"`
 
 	// meta size not in
-	MetaSizeNotIn []float64 `json:"meta_size_not_in,omitempty"`
+	MetaSizeNotIn []int64 `json:"meta_size_not_in,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`
@@ -195,28 +195,28 @@ type ClusterImageWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// upgrade tool version
 	UpgradeToolVersion *string `json:"upgrade_tool_version,omitempty"`

--- a/models/cluster_where_input.go
+++ b/models/cluster_where_input.go
@@ -183,28 +183,28 @@ type ClusterWhereInput struct {
 	EverouteCluster *EverouteClusterWhereInput `json:"everoute_cluster,omitempty"`
 
 	// failure data space
-	FailureDataSpace *float64 `json:"failure_data_space,omitempty"`
+	FailureDataSpace *int64 `json:"failure_data_space,omitempty"`
 
 	// failure data space gt
-	FailureDataSpaceGt *float64 `json:"failure_data_space_gt,omitempty"`
+	FailureDataSpaceGt *int64 `json:"failure_data_space_gt,omitempty"`
 
 	// failure data space gte
-	FailureDataSpaceGte *float64 `json:"failure_data_space_gte,omitempty"`
+	FailureDataSpaceGte *int64 `json:"failure_data_space_gte,omitempty"`
 
 	// failure data space in
-	FailureDataSpaceIn []float64 `json:"failure_data_space_in,omitempty"`
+	FailureDataSpaceIn []int64 `json:"failure_data_space_in,omitempty"`
 
 	// failure data space lt
-	FailureDataSpaceLt *float64 `json:"failure_data_space_lt,omitempty"`
+	FailureDataSpaceLt *int64 `json:"failure_data_space_lt,omitempty"`
 
 	// failure data space lte
-	FailureDataSpaceLte *float64 `json:"failure_data_space_lte,omitempty"`
+	FailureDataSpaceLte *int64 `json:"failure_data_space_lte,omitempty"`
 
 	// failure data space not
-	FailureDataSpaceNot *float64 `json:"failure_data_space_not,omitempty"`
+	FailureDataSpaceNot *int64 `json:"failure_data_space_not,omitempty"`
 
 	// failure data space not in
-	FailureDataSpaceNotIn []float64 `json:"failure_data_space_not_in,omitempty"`
+	FailureDataSpaceNotIn []int64 `json:"failure_data_space_not_in,omitempty"`
 
 	// has metrox
 	HasMetrox *bool `json:"has_metrox,omitempty"`
@@ -663,52 +663,52 @@ type ClusterWhereInput struct {
 	MaxChunkNumNotIn []int32 `json:"max_chunk_num_not_in,omitempty"`
 
 	// max physical data capacity
-	MaxPhysicalDataCapacity *float64 `json:"max_physical_data_capacity,omitempty"`
+	MaxPhysicalDataCapacity *int64 `json:"max_physical_data_capacity,omitempty"`
 
 	// max physical data capacity gt
-	MaxPhysicalDataCapacityGt *float64 `json:"max_physical_data_capacity_gt,omitempty"`
+	MaxPhysicalDataCapacityGt *int64 `json:"max_physical_data_capacity_gt,omitempty"`
 
 	// max physical data capacity gte
-	MaxPhysicalDataCapacityGte *float64 `json:"max_physical_data_capacity_gte,omitempty"`
+	MaxPhysicalDataCapacityGte *int64 `json:"max_physical_data_capacity_gte,omitempty"`
 
 	// max physical data capacity in
-	MaxPhysicalDataCapacityIn []float64 `json:"max_physical_data_capacity_in,omitempty"`
+	MaxPhysicalDataCapacityIn []int64 `json:"max_physical_data_capacity_in,omitempty"`
 
 	// max physical data capacity lt
-	MaxPhysicalDataCapacityLt *float64 `json:"max_physical_data_capacity_lt,omitempty"`
+	MaxPhysicalDataCapacityLt *int64 `json:"max_physical_data_capacity_lt,omitempty"`
 
 	// max physical data capacity lte
-	MaxPhysicalDataCapacityLte *float64 `json:"max_physical_data_capacity_lte,omitempty"`
+	MaxPhysicalDataCapacityLte *int64 `json:"max_physical_data_capacity_lte,omitempty"`
 
 	// max physical data capacity not
-	MaxPhysicalDataCapacityNot *float64 `json:"max_physical_data_capacity_not,omitempty"`
+	MaxPhysicalDataCapacityNot *int64 `json:"max_physical_data_capacity_not,omitempty"`
 
 	// max physical data capacity not in
-	MaxPhysicalDataCapacityNotIn []float64 `json:"max_physical_data_capacity_not_in,omitempty"`
+	MaxPhysicalDataCapacityNotIn []int64 `json:"max_physical_data_capacity_not_in,omitempty"`
 
 	// max physical data capacity per node
-	MaxPhysicalDataCapacityPerNode *float64 `json:"max_physical_data_capacity_per_node,omitempty"`
+	MaxPhysicalDataCapacityPerNode *int64 `json:"max_physical_data_capacity_per_node,omitempty"`
 
 	// max physical data capacity per node gt
-	MaxPhysicalDataCapacityPerNodeGt *float64 `json:"max_physical_data_capacity_per_node_gt,omitempty"`
+	MaxPhysicalDataCapacityPerNodeGt *int64 `json:"max_physical_data_capacity_per_node_gt,omitempty"`
 
 	// max physical data capacity per node gte
-	MaxPhysicalDataCapacityPerNodeGte *float64 `json:"max_physical_data_capacity_per_node_gte,omitempty"`
+	MaxPhysicalDataCapacityPerNodeGte *int64 `json:"max_physical_data_capacity_per_node_gte,omitempty"`
 
 	// max physical data capacity per node in
-	MaxPhysicalDataCapacityPerNodeIn []float64 `json:"max_physical_data_capacity_per_node_in,omitempty"`
+	MaxPhysicalDataCapacityPerNodeIn []int64 `json:"max_physical_data_capacity_per_node_in,omitempty"`
 
 	// max physical data capacity per node lt
-	MaxPhysicalDataCapacityPerNodeLt *float64 `json:"max_physical_data_capacity_per_node_lt,omitempty"`
+	MaxPhysicalDataCapacityPerNodeLt *int64 `json:"max_physical_data_capacity_per_node_lt,omitempty"`
 
 	// max physical data capacity per node lte
-	MaxPhysicalDataCapacityPerNodeLte *float64 `json:"max_physical_data_capacity_per_node_lte,omitempty"`
+	MaxPhysicalDataCapacityPerNodeLte *int64 `json:"max_physical_data_capacity_per_node_lte,omitempty"`
 
 	// max physical data capacity per node not
-	MaxPhysicalDataCapacityPerNodeNot *float64 `json:"max_physical_data_capacity_per_node_not,omitempty"`
+	MaxPhysicalDataCapacityPerNodeNot *int64 `json:"max_physical_data_capacity_per_node_not,omitempty"`
 
 	// max physical data capacity per node not in
-	MaxPhysicalDataCapacityPerNodeNotIn []float64 `json:"max_physical_data_capacity_per_node_not_in,omitempty"`
+	MaxPhysicalDataCapacityPerNodeNotIn []int64 `json:"max_physical_data_capacity_per_node_not_in,omitempty"`
 
 	// mgt gateway
 	MgtGateway *string `json:"mgt_gateway,omitempty"`
@@ -795,52 +795,52 @@ type ClusterWhereInput struct {
 	MgtNetmaskStartsWith *string `json:"mgt_netmask_starts_with,omitempty"`
 
 	// migration data size
-	MigrationDataSize *float64 `json:"migration_data_size,omitempty"`
+	MigrationDataSize *int64 `json:"migration_data_size,omitempty"`
 
 	// migration data size gt
-	MigrationDataSizeGt *float64 `json:"migration_data_size_gt,omitempty"`
+	MigrationDataSizeGt *int64 `json:"migration_data_size_gt,omitempty"`
 
 	// migration data size gte
-	MigrationDataSizeGte *float64 `json:"migration_data_size_gte,omitempty"`
+	MigrationDataSizeGte *int64 `json:"migration_data_size_gte,omitempty"`
 
 	// migration data size in
-	MigrationDataSizeIn []float64 `json:"migration_data_size_in,omitempty"`
+	MigrationDataSizeIn []int64 `json:"migration_data_size_in,omitempty"`
 
 	// migration data size lt
-	MigrationDataSizeLt *float64 `json:"migration_data_size_lt,omitempty"`
+	MigrationDataSizeLt *int64 `json:"migration_data_size_lt,omitempty"`
 
 	// migration data size lte
-	MigrationDataSizeLte *float64 `json:"migration_data_size_lte,omitempty"`
+	MigrationDataSizeLte *int64 `json:"migration_data_size_lte,omitempty"`
 
 	// migration data size not
-	MigrationDataSizeNot *float64 `json:"migration_data_size_not,omitempty"`
+	MigrationDataSizeNot *int64 `json:"migration_data_size_not,omitempty"`
 
 	// migration data size not in
-	MigrationDataSizeNotIn []float64 `json:"migration_data_size_not_in,omitempty"`
+	MigrationDataSizeNotIn []int64 `json:"migration_data_size_not_in,omitempty"`
 
 	// migration speed
-	MigrationSpeed *float64 `json:"migration_speed,omitempty"`
+	MigrationSpeed *int64 `json:"migration_speed,omitempty"`
 
 	// migration speed gt
-	MigrationSpeedGt *float64 `json:"migration_speed_gt,omitempty"`
+	MigrationSpeedGt *int64 `json:"migration_speed_gt,omitempty"`
 
 	// migration speed gte
-	MigrationSpeedGte *float64 `json:"migration_speed_gte,omitempty"`
+	MigrationSpeedGte *int64 `json:"migration_speed_gte,omitempty"`
 
 	// migration speed in
-	MigrationSpeedIn []float64 `json:"migration_speed_in,omitempty"`
+	MigrationSpeedIn []int64 `json:"migration_speed_in,omitempty"`
 
 	// migration speed lt
-	MigrationSpeedLt *float64 `json:"migration_speed_lt,omitempty"`
+	MigrationSpeedLt *int64 `json:"migration_speed_lt,omitempty"`
 
 	// migration speed lte
-	MigrationSpeedLte *float64 `json:"migration_speed_lte,omitempty"`
+	MigrationSpeedLte *int64 `json:"migration_speed_lte,omitempty"`
 
 	// migration speed not
-	MigrationSpeedNot *float64 `json:"migration_speed_not,omitempty"`
+	MigrationSpeedNot *int64 `json:"migration_speed_not,omitempty"`
 
 	// migration speed not in
-	MigrationSpeedNotIn []float64 `json:"migration_speed_not_in,omitempty"`
+	MigrationSpeedNotIn []int64 `json:"migration_speed_not_in,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`
@@ -1023,28 +1023,28 @@ type ClusterWhereInput struct {
 	ProvisionedForActiveVMRatioNotIn []float64 `json:"provisioned_for_active_vm_ratio_not_in,omitempty"`
 
 	// provisioned memory bytes
-	ProvisionedMemoryBytes *float64 `json:"provisioned_memory_bytes,omitempty"`
+	ProvisionedMemoryBytes *int64 `json:"provisioned_memory_bytes,omitempty"`
 
 	// provisioned memory bytes gt
-	ProvisionedMemoryBytesGt *float64 `json:"provisioned_memory_bytes_gt,omitempty"`
+	ProvisionedMemoryBytesGt *int64 `json:"provisioned_memory_bytes_gt,omitempty"`
 
 	// provisioned memory bytes gte
-	ProvisionedMemoryBytesGte *float64 `json:"provisioned_memory_bytes_gte,omitempty"`
+	ProvisionedMemoryBytesGte *int64 `json:"provisioned_memory_bytes_gte,omitempty"`
 
 	// provisioned memory bytes in
-	ProvisionedMemoryBytesIn []float64 `json:"provisioned_memory_bytes_in,omitempty"`
+	ProvisionedMemoryBytesIn []int64 `json:"provisioned_memory_bytes_in,omitempty"`
 
 	// provisioned memory bytes lt
-	ProvisionedMemoryBytesLt *float64 `json:"provisioned_memory_bytes_lt,omitempty"`
+	ProvisionedMemoryBytesLt *int64 `json:"provisioned_memory_bytes_lt,omitempty"`
 
 	// provisioned memory bytes lte
-	ProvisionedMemoryBytesLte *float64 `json:"provisioned_memory_bytes_lte,omitempty"`
+	ProvisionedMemoryBytesLte *int64 `json:"provisioned_memory_bytes_lte,omitempty"`
 
 	// provisioned memory bytes not
-	ProvisionedMemoryBytesNot *float64 `json:"provisioned_memory_bytes_not,omitempty"`
+	ProvisionedMemoryBytesNot *int64 `json:"provisioned_memory_bytes_not,omitempty"`
 
 	// provisioned memory bytes not in
-	ProvisionedMemoryBytesNotIn []float64 `json:"provisioned_memory_bytes_not_in,omitempty"`
+	ProvisionedMemoryBytesNotIn []int64 `json:"provisioned_memory_bytes_not_in,omitempty"`
 
 	// provisioned ratio
 	ProvisionedRatio *float64 `json:"provisioned_ratio,omitempty"`
@@ -1077,52 +1077,52 @@ type ClusterWhereInput struct {
 	RdmaEnabledNot *bool `json:"rdma_enabled_not,omitempty"`
 
 	// recover data size
-	RecoverDataSize *float64 `json:"recover_data_size,omitempty"`
+	RecoverDataSize *int64 `json:"recover_data_size,omitempty"`
 
 	// recover data size gt
-	RecoverDataSizeGt *float64 `json:"recover_data_size_gt,omitempty"`
+	RecoverDataSizeGt *int64 `json:"recover_data_size_gt,omitempty"`
 
 	// recover data size gte
-	RecoverDataSizeGte *float64 `json:"recover_data_size_gte,omitempty"`
+	RecoverDataSizeGte *int64 `json:"recover_data_size_gte,omitempty"`
 
 	// recover data size in
-	RecoverDataSizeIn []float64 `json:"recover_data_size_in,omitempty"`
+	RecoverDataSizeIn []int64 `json:"recover_data_size_in,omitempty"`
 
 	// recover data size lt
-	RecoverDataSizeLt *float64 `json:"recover_data_size_lt,omitempty"`
+	RecoverDataSizeLt *int64 `json:"recover_data_size_lt,omitempty"`
 
 	// recover data size lte
-	RecoverDataSizeLte *float64 `json:"recover_data_size_lte,omitempty"`
+	RecoverDataSizeLte *int64 `json:"recover_data_size_lte,omitempty"`
 
 	// recover data size not
-	RecoverDataSizeNot *float64 `json:"recover_data_size_not,omitempty"`
+	RecoverDataSizeNot *int64 `json:"recover_data_size_not,omitempty"`
 
 	// recover data size not in
-	RecoverDataSizeNotIn []float64 `json:"recover_data_size_not_in,omitempty"`
+	RecoverDataSizeNotIn []int64 `json:"recover_data_size_not_in,omitempty"`
 
 	// recover speed
-	RecoverSpeed *float64 `json:"recover_speed,omitempty"`
+	RecoverSpeed *int64 `json:"recover_speed,omitempty"`
 
 	// recover speed gt
-	RecoverSpeedGt *float64 `json:"recover_speed_gt,omitempty"`
+	RecoverSpeedGt *int64 `json:"recover_speed_gt,omitempty"`
 
 	// recover speed gte
-	RecoverSpeedGte *float64 `json:"recover_speed_gte,omitempty"`
+	RecoverSpeedGte *int64 `json:"recover_speed_gte,omitempty"`
 
 	// recover speed in
-	RecoverSpeedIn []float64 `json:"recover_speed_in,omitempty"`
+	RecoverSpeedIn []int64 `json:"recover_speed_in,omitempty"`
 
 	// recover speed lt
-	RecoverSpeedLt *float64 `json:"recover_speed_lt,omitempty"`
+	RecoverSpeedLt *int64 `json:"recover_speed_lt,omitempty"`
 
 	// recover speed lte
-	RecoverSpeedLte *float64 `json:"recover_speed_lte,omitempty"`
+	RecoverSpeedLte *int64 `json:"recover_speed_lte,omitempty"`
 
 	// recover speed not
-	RecoverSpeedNot *float64 `json:"recover_speed_not,omitempty"`
+	RecoverSpeedNot *int64 `json:"recover_speed_not,omitempty"`
 
 	// recover speed not in
-	RecoverSpeedNotIn []float64 `json:"recover_speed_not_in,omitempty"`
+	RecoverSpeedNotIn []int64 `json:"recover_speed_not_in,omitempty"`
 
 	// reserved cpu cores for system service
 	ReservedCPUCoresForSystemService *int32 `json:"reserved_cpu_cores_for_system_service,omitempty"`
@@ -1242,28 +1242,28 @@ type ClusterWhereInput struct {
 	SuspendedVMNumNotIn []int32 `json:"suspended_vm_num_not_in,omitempty"`
 
 	// total cache capacity
-	TotalCacheCapacity *float64 `json:"total_cache_capacity,omitempty"`
+	TotalCacheCapacity *int64 `json:"total_cache_capacity,omitempty"`
 
 	// total cache capacity gt
-	TotalCacheCapacityGt *float64 `json:"total_cache_capacity_gt,omitempty"`
+	TotalCacheCapacityGt *int64 `json:"total_cache_capacity_gt,omitempty"`
 
 	// total cache capacity gte
-	TotalCacheCapacityGte *float64 `json:"total_cache_capacity_gte,omitempty"`
+	TotalCacheCapacityGte *int64 `json:"total_cache_capacity_gte,omitempty"`
 
 	// total cache capacity in
-	TotalCacheCapacityIn []float64 `json:"total_cache_capacity_in,omitempty"`
+	TotalCacheCapacityIn []int64 `json:"total_cache_capacity_in,omitempty"`
 
 	// total cache capacity lt
-	TotalCacheCapacityLt *float64 `json:"total_cache_capacity_lt,omitempty"`
+	TotalCacheCapacityLt *int64 `json:"total_cache_capacity_lt,omitempty"`
 
 	// total cache capacity lte
-	TotalCacheCapacityLte *float64 `json:"total_cache_capacity_lte,omitempty"`
+	TotalCacheCapacityLte *int64 `json:"total_cache_capacity_lte,omitempty"`
 
 	// total cache capacity not
-	TotalCacheCapacityNot *float64 `json:"total_cache_capacity_not,omitempty"`
+	TotalCacheCapacityNot *int64 `json:"total_cache_capacity_not,omitempty"`
 
 	// total cache capacity not in
-	TotalCacheCapacityNotIn []float64 `json:"total_cache_capacity_not_in,omitempty"`
+	TotalCacheCapacityNotIn []int64 `json:"total_cache_capacity_not_in,omitempty"`
 
 	// total cpu cores
 	TotalCPUCores *int32 `json:"total_cpu_cores,omitempty"`
@@ -1290,28 +1290,28 @@ type ClusterWhereInput struct {
 	TotalCPUCoresNotIn []int32 `json:"total_cpu_cores_not_in,omitempty"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total cpu hz gt
-	TotalCPUHzGt *float64 `json:"total_cpu_hz_gt,omitempty"`
+	TotalCPUHzGt *int64 `json:"total_cpu_hz_gt,omitempty"`
 
 	// total cpu hz gte
-	TotalCPUHzGte *float64 `json:"total_cpu_hz_gte,omitempty"`
+	TotalCPUHzGte *int64 `json:"total_cpu_hz_gte,omitempty"`
 
 	// total cpu hz in
-	TotalCPUHzIn []float64 `json:"total_cpu_hz_in,omitempty"`
+	TotalCPUHzIn []int64 `json:"total_cpu_hz_in,omitempty"`
 
 	// total cpu hz lt
-	TotalCPUHzLt *float64 `json:"total_cpu_hz_lt,omitempty"`
+	TotalCPUHzLt *int64 `json:"total_cpu_hz_lt,omitempty"`
 
 	// total cpu hz lte
-	TotalCPUHzLte *float64 `json:"total_cpu_hz_lte,omitempty"`
+	TotalCPUHzLte *int64 `json:"total_cpu_hz_lte,omitempty"`
 
 	// total cpu hz not
-	TotalCPUHzNot *float64 `json:"total_cpu_hz_not,omitempty"`
+	TotalCPUHzNot *int64 `json:"total_cpu_hz_not,omitempty"`
 
 	// total cpu hz not in
-	TotalCPUHzNotIn []float64 `json:"total_cpu_hz_not_in,omitempty"`
+	TotalCPUHzNotIn []int64 `json:"total_cpu_hz_not_in,omitempty"`
 
 	// total cpu sockets
 	TotalCPUSockets *int32 `json:"total_cpu_sockets,omitempty"`
@@ -1338,52 +1338,52 @@ type ClusterWhereInput struct {
 	TotalCPUSocketsNotIn []int32 `json:"total_cpu_sockets_not_in,omitempty"`
 
 	// total data capacity
-	TotalDataCapacity *float64 `json:"total_data_capacity,omitempty"`
+	TotalDataCapacity *int64 `json:"total_data_capacity,omitempty"`
 
 	// total data capacity gt
-	TotalDataCapacityGt *float64 `json:"total_data_capacity_gt,omitempty"`
+	TotalDataCapacityGt *int64 `json:"total_data_capacity_gt,omitempty"`
 
 	// total data capacity gte
-	TotalDataCapacityGte *float64 `json:"total_data_capacity_gte,omitempty"`
+	TotalDataCapacityGte *int64 `json:"total_data_capacity_gte,omitempty"`
 
 	// total data capacity in
-	TotalDataCapacityIn []float64 `json:"total_data_capacity_in,omitempty"`
+	TotalDataCapacityIn []int64 `json:"total_data_capacity_in,omitempty"`
 
 	// total data capacity lt
-	TotalDataCapacityLt *float64 `json:"total_data_capacity_lt,omitempty"`
+	TotalDataCapacityLt *int64 `json:"total_data_capacity_lt,omitempty"`
 
 	// total data capacity lte
-	TotalDataCapacityLte *float64 `json:"total_data_capacity_lte,omitempty"`
+	TotalDataCapacityLte *int64 `json:"total_data_capacity_lte,omitempty"`
 
 	// total data capacity not
-	TotalDataCapacityNot *float64 `json:"total_data_capacity_not,omitempty"`
+	TotalDataCapacityNot *int64 `json:"total_data_capacity_not,omitempty"`
 
 	// total data capacity not in
-	TotalDataCapacityNotIn []float64 `json:"total_data_capacity_not_in,omitempty"`
+	TotalDataCapacityNotIn []int64 `json:"total_data_capacity_not_in,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// total memory bytes gt
-	TotalMemoryBytesGt *float64 `json:"total_memory_bytes_gt,omitempty"`
+	TotalMemoryBytesGt *int64 `json:"total_memory_bytes_gt,omitempty"`
 
 	// total memory bytes gte
-	TotalMemoryBytesGte *float64 `json:"total_memory_bytes_gte,omitempty"`
+	TotalMemoryBytesGte *int64 `json:"total_memory_bytes_gte,omitempty"`
 
 	// total memory bytes in
-	TotalMemoryBytesIn []float64 `json:"total_memory_bytes_in,omitempty"`
+	TotalMemoryBytesIn []int64 `json:"total_memory_bytes_in,omitempty"`
 
 	// total memory bytes lt
-	TotalMemoryBytesLt *float64 `json:"total_memory_bytes_lt,omitempty"`
+	TotalMemoryBytesLt *int64 `json:"total_memory_bytes_lt,omitempty"`
 
 	// total memory bytes lte
-	TotalMemoryBytesLte *float64 `json:"total_memory_bytes_lte,omitempty"`
+	TotalMemoryBytesLte *int64 `json:"total_memory_bytes_lte,omitempty"`
 
 	// total memory bytes not
-	TotalMemoryBytesNot *float64 `json:"total_memory_bytes_not,omitempty"`
+	TotalMemoryBytesNot *int64 `json:"total_memory_bytes_not,omitempty"`
 
 	// total memory bytes not in
-	TotalMemoryBytesNotIn []float64 `json:"total_memory_bytes_not_in,omitempty"`
+	TotalMemoryBytesNotIn []int64 `json:"total_memory_bytes_not_in,omitempty"`
 
 	// type
 	Type *ClusterType `json:"type,omitempty"`
@@ -1440,76 +1440,76 @@ type ClusterWhereInput struct {
 	UpgradeToolVersionStartsWith *string `json:"upgrade_tool_version_starts_with,omitempty"`
 
 	// used cpu hz
-	UsedCPUHz *float64 `json:"used_cpu_hz,omitempty"`
+	UsedCPUHz *int64 `json:"used_cpu_hz,omitempty"`
 
 	// used cpu hz gt
-	UsedCPUHzGt *float64 `json:"used_cpu_hz_gt,omitempty"`
+	UsedCPUHzGt *int64 `json:"used_cpu_hz_gt,omitempty"`
 
 	// used cpu hz gte
-	UsedCPUHzGte *float64 `json:"used_cpu_hz_gte,omitempty"`
+	UsedCPUHzGte *int64 `json:"used_cpu_hz_gte,omitempty"`
 
 	// used cpu hz in
-	UsedCPUHzIn []float64 `json:"used_cpu_hz_in,omitempty"`
+	UsedCPUHzIn []int64 `json:"used_cpu_hz_in,omitempty"`
 
 	// used cpu hz lt
-	UsedCPUHzLt *float64 `json:"used_cpu_hz_lt,omitempty"`
+	UsedCPUHzLt *int64 `json:"used_cpu_hz_lt,omitempty"`
 
 	// used cpu hz lte
-	UsedCPUHzLte *float64 `json:"used_cpu_hz_lte,omitempty"`
+	UsedCPUHzLte *int64 `json:"used_cpu_hz_lte,omitempty"`
 
 	// used cpu hz not
-	UsedCPUHzNot *float64 `json:"used_cpu_hz_not,omitempty"`
+	UsedCPUHzNot *int64 `json:"used_cpu_hz_not,omitempty"`
 
 	// used cpu hz not in
-	UsedCPUHzNotIn []float64 `json:"used_cpu_hz_not_in,omitempty"`
+	UsedCPUHzNotIn []int64 `json:"used_cpu_hz_not_in,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// used data space gt
-	UsedDataSpaceGt *float64 `json:"used_data_space_gt,omitempty"`
+	UsedDataSpaceGt *int64 `json:"used_data_space_gt,omitempty"`
 
 	// used data space gte
-	UsedDataSpaceGte *float64 `json:"used_data_space_gte,omitempty"`
+	UsedDataSpaceGte *int64 `json:"used_data_space_gte,omitempty"`
 
 	// used data space in
-	UsedDataSpaceIn []float64 `json:"used_data_space_in,omitempty"`
+	UsedDataSpaceIn []int64 `json:"used_data_space_in,omitempty"`
 
 	// used data space lt
-	UsedDataSpaceLt *float64 `json:"used_data_space_lt,omitempty"`
+	UsedDataSpaceLt *int64 `json:"used_data_space_lt,omitempty"`
 
 	// used data space lte
-	UsedDataSpaceLte *float64 `json:"used_data_space_lte,omitempty"`
+	UsedDataSpaceLte *int64 `json:"used_data_space_lte,omitempty"`
 
 	// used data space not
-	UsedDataSpaceNot *float64 `json:"used_data_space_not,omitempty"`
+	UsedDataSpaceNot *int64 `json:"used_data_space_not,omitempty"`
 
 	// used data space not in
-	UsedDataSpaceNotIn []float64 `json:"used_data_space_not_in,omitempty"`
+	UsedDataSpaceNotIn []int64 `json:"used_data_space_not_in,omitempty"`
 
 	// used memory bytes
-	UsedMemoryBytes *float64 `json:"used_memory_bytes,omitempty"`
+	UsedMemoryBytes *int64 `json:"used_memory_bytes,omitempty"`
 
 	// used memory bytes gt
-	UsedMemoryBytesGt *float64 `json:"used_memory_bytes_gt,omitempty"`
+	UsedMemoryBytesGt *int64 `json:"used_memory_bytes_gt,omitempty"`
 
 	// used memory bytes gte
-	UsedMemoryBytesGte *float64 `json:"used_memory_bytes_gte,omitempty"`
+	UsedMemoryBytesGte *int64 `json:"used_memory_bytes_gte,omitempty"`
 
 	// used memory bytes in
-	UsedMemoryBytesIn []float64 `json:"used_memory_bytes_in,omitempty"`
+	UsedMemoryBytesIn []int64 `json:"used_memory_bytes_in,omitempty"`
 
 	// used memory bytes lt
-	UsedMemoryBytesLt *float64 `json:"used_memory_bytes_lt,omitempty"`
+	UsedMemoryBytesLt *int64 `json:"used_memory_bytes_lt,omitempty"`
 
 	// used memory bytes lte
-	UsedMemoryBytesLte *float64 `json:"used_memory_bytes_lte,omitempty"`
+	UsedMemoryBytesLte *int64 `json:"used_memory_bytes_lte,omitempty"`
 
 	// used memory bytes not
-	UsedMemoryBytesNot *float64 `json:"used_memory_bytes_not,omitempty"`
+	UsedMemoryBytesNot *int64 `json:"used_memory_bytes_not,omitempty"`
 
 	// used memory bytes not in
-	UsedMemoryBytesNotIn []float64 `json:"used_memory_bytes_not_in,omitempty"`
+	UsedMemoryBytesNotIn []int64 `json:"used_memory_bytes_not_in,omitempty"`
 
 	// username
 	Username *string `json:"username,omitempty"`
@@ -1554,28 +1554,28 @@ type ClusterWhereInput struct {
 	UsernameStartsWith *string `json:"username_starts_with,omitempty"`
 
 	// valid data space
-	ValidDataSpace *float64 `json:"valid_data_space,omitempty"`
+	ValidDataSpace *int64 `json:"valid_data_space,omitempty"`
 
 	// valid data space gt
-	ValidDataSpaceGt *float64 `json:"valid_data_space_gt,omitempty"`
+	ValidDataSpaceGt *int64 `json:"valid_data_space_gt,omitempty"`
 
 	// valid data space gte
-	ValidDataSpaceGte *float64 `json:"valid_data_space_gte,omitempty"`
+	ValidDataSpaceGte *int64 `json:"valid_data_space_gte,omitempty"`
 
 	// valid data space in
-	ValidDataSpaceIn []float64 `json:"valid_data_space_in,omitempty"`
+	ValidDataSpaceIn []int64 `json:"valid_data_space_in,omitempty"`
 
 	// valid data space lt
-	ValidDataSpaceLt *float64 `json:"valid_data_space_lt,omitempty"`
+	ValidDataSpaceLt *int64 `json:"valid_data_space_lt,omitempty"`
 
 	// valid data space lte
-	ValidDataSpaceLte *float64 `json:"valid_data_space_lte,omitempty"`
+	ValidDataSpaceLte *int64 `json:"valid_data_space_lte,omitempty"`
 
 	// valid data space not
-	ValidDataSpaceNot *float64 `json:"valid_data_space_not,omitempty"`
+	ValidDataSpaceNot *int64 `json:"valid_data_space_not,omitempty"`
 
 	// valid data space not in
-	ValidDataSpaceNotIn []float64 `json:"valid_data_space_not_in,omitempty"`
+	ValidDataSpaceNotIn []int64 `json:"valid_data_space_not_in,omitempty"`
 
 	// vcenter account
 	VcenterAccount *VcenterAccountWhereInput `json:"vcenterAccount,omitempty"`

--- a/models/consistency_group.go
+++ b/models/consistency_group.go
@@ -61,7 +61,7 @@ type ConsistencyGroup struct {
 
 	// unique size
 	// Required: true
-	UniqueSize *float64 `json:"unique_size"`
+	UniqueSize *int64 `json:"unique_size"`
 }
 
 // Validate validates this consistency group

--- a/models/consistency_group_snapshot.go
+++ b/models/consistency_group_snapshot.go
@@ -53,7 +53,7 @@ type ConsistencyGroupSnapshot struct {
 
 	// unique size
 	// Required: true
-	UniqueSize *float64 `json:"unique_size"`
+	UniqueSize *int64 `json:"unique_size"`
 }
 
 // Validate validates this consistency group snapshot

--- a/models/consistency_group_snapshot_where_input.go
+++ b/models/consistency_group_snapshot_where_input.go
@@ -222,28 +222,28 @@ type ConsistencyGroupSnapshotWhereInput struct {
 	NvmfNamespaceSnapshotsSome *NvmfNamespaceSnapshotWhereInput `json:"nvmf_namespace_snapshots_some,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 }
 
 // Validate validates this consistency group snapshot where input

--- a/models/consistency_group_where_input.go
+++ b/models/consistency_group_where_input.go
@@ -273,28 +273,28 @@ type ConsistencyGroupWhereInput struct {
 	NamespacesSome *NvmfNamespaceWhereInput `json:"namespaces_some,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 }
 
 // Validate validates this consistency group where input

--- a/models/content_library_image.go
+++ b/models/content_library_image.go
@@ -58,7 +58,7 @@ type ContentLibraryImage struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// vm disks
 	VMDisks []*NestedVMDisk `json:"vm_disks,omitempty"`

--- a/models/content_library_image_where_input.go
+++ b/models/content_library_image_where_input.go
@@ -261,28 +261,28 @@ type ContentLibraryImageWhereInput struct {
 	PathStartsWith *string `json:"path_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// vm disks every
 	VMDisksEvery *VMDiskWhereInput `json:"vm_disks_every,omitempty"`

--- a/models/content_library_vm_template.go
+++ b/models/content_library_vm_template.go
@@ -51,7 +51,7 @@ type ContentLibraryVMTemplate struct {
 
 	// memory
 	// Required: true
-	Memory *float64 `json:"memory"`
+	Memory *int64 `json:"memory"`
 
 	// name
 	// Required: true
@@ -62,7 +62,7 @@ type ContentLibraryVMTemplate struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// vcpu
 	// Required: true

--- a/models/content_library_vm_template_where_input.go
+++ b/models/content_library_vm_template_where_input.go
@@ -186,28 +186,28 @@ type ContentLibraryVMTemplateWhereInput struct {
 	LabelsSome *LabelWhereInput `json:"labels_some,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// memory gt
-	MemoryGt *float64 `json:"memory_gt,omitempty"`
+	MemoryGt *int64 `json:"memory_gt,omitempty"`
 
 	// memory gte
-	MemoryGte *float64 `json:"memory_gte,omitempty"`
+	MemoryGte *int64 `json:"memory_gte,omitempty"`
 
 	// memory in
-	MemoryIn []float64 `json:"memory_in,omitempty"`
+	MemoryIn []int64 `json:"memory_in,omitempty"`
 
 	// memory lt
-	MemoryLt *float64 `json:"memory_lt,omitempty"`
+	MemoryLt *int64 `json:"memory_lt,omitempty"`
 
 	// memory lte
-	MemoryLte *float64 `json:"memory_lte,omitempty"`
+	MemoryLte *int64 `json:"memory_lte,omitempty"`
 
 	// memory not
-	MemoryNot *float64 `json:"memory_not,omitempty"`
+	MemoryNot *int64 `json:"memory_not,omitempty"`
 
 	// memory not in
-	MemoryNotIn []float64 `json:"memory_not_in,omitempty"`
+	MemoryNotIn []int64 `json:"memory_not_in,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`
@@ -294,28 +294,28 @@ type ContentLibraryVMTemplateWhereInput struct {
 	OsStartsWith *string `json:"os_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// vcpu
 	Vcpu *int32 `json:"vcpu,omitempty"`

--- a/models/datacenter.go
+++ b/models/datacenter.go
@@ -27,7 +27,7 @@ type Datacenter struct {
 	Clusters []*NestedCluster `json:"clusters,omitempty"`
 
 	// failure data space
-	FailureDataSpace *float64 `json:"failure_data_space,omitempty"`
+	FailureDataSpace *int64 `json:"failure_data_space,omitempty"`
 
 	// host num
 	HostNum *int32 `json:"host_num,omitempty"`
@@ -48,22 +48,22 @@ type Datacenter struct {
 	Organization *NestedOrganization `json:"organization"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total data capacity
-	TotalDataCapacity *float64 `json:"total_data_capacity,omitempty"`
+	TotalDataCapacity *int64 `json:"total_data_capacity,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// used cpu hz
-	UsedCPUHz *float64 `json:"used_cpu_hz,omitempty"`
+	UsedCPUHz *int64 `json:"used_cpu_hz,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// used memory bytes
-	UsedMemoryBytes *float64 `json:"used_memory_bytes,omitempty"`
+	UsedMemoryBytes *int64 `json:"used_memory_bytes,omitempty"`
 
 	// vm num
 	VMNum *int32 `json:"vm_num,omitempty"`

--- a/models/datacenter_where_input.go
+++ b/models/datacenter_where_input.go
@@ -63,28 +63,28 @@ type DatacenterWhereInput struct {
 	ClustersSome *ClusterWhereInput `json:"clusters_some,omitempty"`
 
 	// failure data space
-	FailureDataSpace *float64 `json:"failure_data_space,omitempty"`
+	FailureDataSpace *int64 `json:"failure_data_space,omitempty"`
 
 	// failure data space gt
-	FailureDataSpaceGt *float64 `json:"failure_data_space_gt,omitempty"`
+	FailureDataSpaceGt *int64 `json:"failure_data_space_gt,omitempty"`
 
 	// failure data space gte
-	FailureDataSpaceGte *float64 `json:"failure_data_space_gte,omitempty"`
+	FailureDataSpaceGte *int64 `json:"failure_data_space_gte,omitempty"`
 
 	// failure data space in
-	FailureDataSpaceIn []float64 `json:"failure_data_space_in,omitempty"`
+	FailureDataSpaceIn []int64 `json:"failure_data_space_in,omitempty"`
 
 	// failure data space lt
-	FailureDataSpaceLt *float64 `json:"failure_data_space_lt,omitempty"`
+	FailureDataSpaceLt *int64 `json:"failure_data_space_lt,omitempty"`
 
 	// failure data space lte
-	FailureDataSpaceLte *float64 `json:"failure_data_space_lte,omitempty"`
+	FailureDataSpaceLte *int64 `json:"failure_data_space_lte,omitempty"`
 
 	// failure data space not
-	FailureDataSpaceNot *float64 `json:"failure_data_space_not,omitempty"`
+	FailureDataSpaceNot *int64 `json:"failure_data_space_not,omitempty"`
 
 	// failure data space not in
-	FailureDataSpaceNotIn []float64 `json:"failure_data_space_not_in,omitempty"`
+	FailureDataSpaceNotIn []int64 `json:"failure_data_space_not_in,omitempty"`
 
 	// host num
 	HostNum *int32 `json:"host_num,omitempty"`
@@ -207,148 +207,148 @@ type DatacenterWhereInput struct {
 	Organization *OrganizationWhereInput `json:"organization,omitempty"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total cpu hz gt
-	TotalCPUHzGt *float64 `json:"total_cpu_hz_gt,omitempty"`
+	TotalCPUHzGt *int64 `json:"total_cpu_hz_gt,omitempty"`
 
 	// total cpu hz gte
-	TotalCPUHzGte *float64 `json:"total_cpu_hz_gte,omitempty"`
+	TotalCPUHzGte *int64 `json:"total_cpu_hz_gte,omitempty"`
 
 	// total cpu hz in
-	TotalCPUHzIn []float64 `json:"total_cpu_hz_in,omitempty"`
+	TotalCPUHzIn []int64 `json:"total_cpu_hz_in,omitempty"`
 
 	// total cpu hz lt
-	TotalCPUHzLt *float64 `json:"total_cpu_hz_lt,omitempty"`
+	TotalCPUHzLt *int64 `json:"total_cpu_hz_lt,omitempty"`
 
 	// total cpu hz lte
-	TotalCPUHzLte *float64 `json:"total_cpu_hz_lte,omitempty"`
+	TotalCPUHzLte *int64 `json:"total_cpu_hz_lte,omitempty"`
 
 	// total cpu hz not
-	TotalCPUHzNot *float64 `json:"total_cpu_hz_not,omitempty"`
+	TotalCPUHzNot *int64 `json:"total_cpu_hz_not,omitempty"`
 
 	// total cpu hz not in
-	TotalCPUHzNotIn []float64 `json:"total_cpu_hz_not_in,omitempty"`
+	TotalCPUHzNotIn []int64 `json:"total_cpu_hz_not_in,omitempty"`
 
 	// total data capacity
-	TotalDataCapacity *float64 `json:"total_data_capacity,omitempty"`
+	TotalDataCapacity *int64 `json:"total_data_capacity,omitempty"`
 
 	// total data capacity gt
-	TotalDataCapacityGt *float64 `json:"total_data_capacity_gt,omitempty"`
+	TotalDataCapacityGt *int64 `json:"total_data_capacity_gt,omitempty"`
 
 	// total data capacity gte
-	TotalDataCapacityGte *float64 `json:"total_data_capacity_gte,omitempty"`
+	TotalDataCapacityGte *int64 `json:"total_data_capacity_gte,omitempty"`
 
 	// total data capacity in
-	TotalDataCapacityIn []float64 `json:"total_data_capacity_in,omitempty"`
+	TotalDataCapacityIn []int64 `json:"total_data_capacity_in,omitempty"`
 
 	// total data capacity lt
-	TotalDataCapacityLt *float64 `json:"total_data_capacity_lt,omitempty"`
+	TotalDataCapacityLt *int64 `json:"total_data_capacity_lt,omitempty"`
 
 	// total data capacity lte
-	TotalDataCapacityLte *float64 `json:"total_data_capacity_lte,omitempty"`
+	TotalDataCapacityLte *int64 `json:"total_data_capacity_lte,omitempty"`
 
 	// total data capacity not
-	TotalDataCapacityNot *float64 `json:"total_data_capacity_not,omitempty"`
+	TotalDataCapacityNot *int64 `json:"total_data_capacity_not,omitempty"`
 
 	// total data capacity not in
-	TotalDataCapacityNotIn []float64 `json:"total_data_capacity_not_in,omitempty"`
+	TotalDataCapacityNotIn []int64 `json:"total_data_capacity_not_in,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// total memory bytes gt
-	TotalMemoryBytesGt *float64 `json:"total_memory_bytes_gt,omitempty"`
+	TotalMemoryBytesGt *int64 `json:"total_memory_bytes_gt,omitempty"`
 
 	// total memory bytes gte
-	TotalMemoryBytesGte *float64 `json:"total_memory_bytes_gte,omitempty"`
+	TotalMemoryBytesGte *int64 `json:"total_memory_bytes_gte,omitempty"`
 
 	// total memory bytes in
-	TotalMemoryBytesIn []float64 `json:"total_memory_bytes_in,omitempty"`
+	TotalMemoryBytesIn []int64 `json:"total_memory_bytes_in,omitempty"`
 
 	// total memory bytes lt
-	TotalMemoryBytesLt *float64 `json:"total_memory_bytes_lt,omitempty"`
+	TotalMemoryBytesLt *int64 `json:"total_memory_bytes_lt,omitempty"`
 
 	// total memory bytes lte
-	TotalMemoryBytesLte *float64 `json:"total_memory_bytes_lte,omitempty"`
+	TotalMemoryBytesLte *int64 `json:"total_memory_bytes_lte,omitempty"`
 
 	// total memory bytes not
-	TotalMemoryBytesNot *float64 `json:"total_memory_bytes_not,omitempty"`
+	TotalMemoryBytesNot *int64 `json:"total_memory_bytes_not,omitempty"`
 
 	// total memory bytes not in
-	TotalMemoryBytesNotIn []float64 `json:"total_memory_bytes_not_in,omitempty"`
+	TotalMemoryBytesNotIn []int64 `json:"total_memory_bytes_not_in,omitempty"`
 
 	// used cpu hz
-	UsedCPUHz *float64 `json:"used_cpu_hz,omitempty"`
+	UsedCPUHz *int64 `json:"used_cpu_hz,omitempty"`
 
 	// used cpu hz gt
-	UsedCPUHzGt *float64 `json:"used_cpu_hz_gt,omitempty"`
+	UsedCPUHzGt *int64 `json:"used_cpu_hz_gt,omitempty"`
 
 	// used cpu hz gte
-	UsedCPUHzGte *float64 `json:"used_cpu_hz_gte,omitempty"`
+	UsedCPUHzGte *int64 `json:"used_cpu_hz_gte,omitempty"`
 
 	// used cpu hz in
-	UsedCPUHzIn []float64 `json:"used_cpu_hz_in,omitempty"`
+	UsedCPUHzIn []int64 `json:"used_cpu_hz_in,omitempty"`
 
 	// used cpu hz lt
-	UsedCPUHzLt *float64 `json:"used_cpu_hz_lt,omitempty"`
+	UsedCPUHzLt *int64 `json:"used_cpu_hz_lt,omitempty"`
 
 	// used cpu hz lte
-	UsedCPUHzLte *float64 `json:"used_cpu_hz_lte,omitempty"`
+	UsedCPUHzLte *int64 `json:"used_cpu_hz_lte,omitempty"`
 
 	// used cpu hz not
-	UsedCPUHzNot *float64 `json:"used_cpu_hz_not,omitempty"`
+	UsedCPUHzNot *int64 `json:"used_cpu_hz_not,omitempty"`
 
 	// used cpu hz not in
-	UsedCPUHzNotIn []float64 `json:"used_cpu_hz_not_in,omitempty"`
+	UsedCPUHzNotIn []int64 `json:"used_cpu_hz_not_in,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// used data space gt
-	UsedDataSpaceGt *float64 `json:"used_data_space_gt,omitempty"`
+	UsedDataSpaceGt *int64 `json:"used_data_space_gt,omitempty"`
 
 	// used data space gte
-	UsedDataSpaceGte *float64 `json:"used_data_space_gte,omitempty"`
+	UsedDataSpaceGte *int64 `json:"used_data_space_gte,omitempty"`
 
 	// used data space in
-	UsedDataSpaceIn []float64 `json:"used_data_space_in,omitempty"`
+	UsedDataSpaceIn []int64 `json:"used_data_space_in,omitempty"`
 
 	// used data space lt
-	UsedDataSpaceLt *float64 `json:"used_data_space_lt,omitempty"`
+	UsedDataSpaceLt *int64 `json:"used_data_space_lt,omitempty"`
 
 	// used data space lte
-	UsedDataSpaceLte *float64 `json:"used_data_space_lte,omitempty"`
+	UsedDataSpaceLte *int64 `json:"used_data_space_lte,omitempty"`
 
 	// used data space not
-	UsedDataSpaceNot *float64 `json:"used_data_space_not,omitempty"`
+	UsedDataSpaceNot *int64 `json:"used_data_space_not,omitempty"`
 
 	// used data space not in
-	UsedDataSpaceNotIn []float64 `json:"used_data_space_not_in,omitempty"`
+	UsedDataSpaceNotIn []int64 `json:"used_data_space_not_in,omitempty"`
 
 	// used memory bytes
-	UsedMemoryBytes *float64 `json:"used_memory_bytes,omitempty"`
+	UsedMemoryBytes *int64 `json:"used_memory_bytes,omitempty"`
 
 	// used memory bytes gt
-	UsedMemoryBytesGt *float64 `json:"used_memory_bytes_gt,omitempty"`
+	UsedMemoryBytesGt *int64 `json:"used_memory_bytes_gt,omitempty"`
 
 	// used memory bytes gte
-	UsedMemoryBytesGte *float64 `json:"used_memory_bytes_gte,omitempty"`
+	UsedMemoryBytesGte *int64 `json:"used_memory_bytes_gte,omitempty"`
 
 	// used memory bytes in
-	UsedMemoryBytesIn []float64 `json:"used_memory_bytes_in,omitempty"`
+	UsedMemoryBytesIn []int64 `json:"used_memory_bytes_in,omitempty"`
 
 	// used memory bytes lt
-	UsedMemoryBytesLt *float64 `json:"used_memory_bytes_lt,omitempty"`
+	UsedMemoryBytesLt *int64 `json:"used_memory_bytes_lt,omitempty"`
 
 	// used memory bytes lte
-	UsedMemoryBytesLte *float64 `json:"used_memory_bytes_lte,omitempty"`
+	UsedMemoryBytesLte *int64 `json:"used_memory_bytes_lte,omitempty"`
 
 	// used memory bytes not
-	UsedMemoryBytesNot *float64 `json:"used_memory_bytes_not,omitempty"`
+	UsedMemoryBytesNot *int64 `json:"used_memory_bytes_not,omitempty"`
 
 	// used memory bytes not in
-	UsedMemoryBytesNotIn []float64 `json:"used_memory_bytes_not_in,omitempty"`
+	UsedMemoryBytesNotIn []int64 `json:"used_memory_bytes_not_in,omitempty"`
 
 	// vm num
 	VMNum *int32 `json:"vm_num,omitempty"`

--- a/models/disk.go
+++ b/models/disk.go
@@ -103,7 +103,7 @@ type Disk struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// type
 	// Required: true

--- a/models/disk_where_input.go
+++ b/models/disk_where_input.go
@@ -525,28 +525,28 @@ type DiskWhereInput struct {
 	SerialStartsWith *string `json:"serial_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// type
 	Type *DiskType `json:"type,omitempty"`

--- a/models/elf_image.go
+++ b/models/elf_image.go
@@ -58,7 +58,7 @@ type ElfImage struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// upload task
 	UploadTask *NestedUploadTask `json:"upload_task,omitempty"`

--- a/models/elf_image_where_input.go
+++ b/models/elf_image_where_input.go
@@ -291,28 +291,28 @@ type ElfImageWhereInput struct {
 	PathStartsWith *string `json:"path_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// vm disks every
 	VMDisksEvery *VMDiskWhereInput `json:"vm_disks_every,omitempty"`

--- a/models/elf_storage_policy.go
+++ b/models/elf_storage_policy.go
@@ -52,7 +52,7 @@ type ElfStoragePolicy struct {
 
 	// stripe size
 	// Required: true
-	StripeSize *float64 `json:"stripe_size"`
+	StripeSize *int64 `json:"stripe_size"`
 
 	// thin provision
 	// Required: true

--- a/models/elf_storage_policy_where_input.go
+++ b/models/elf_storage_policy_where_input.go
@@ -261,28 +261,28 @@ type ElfStoragePolicyWhereInput struct {
 	StripeNumNotIn []int32 `json:"stripe_num_not_in,omitempty"`
 
 	// stripe size
-	StripeSize *float64 `json:"stripe_size,omitempty"`
+	StripeSize *int64 `json:"stripe_size,omitempty"`
 
 	// stripe size gt
-	StripeSizeGt *float64 `json:"stripe_size_gt,omitempty"`
+	StripeSizeGt *int64 `json:"stripe_size_gt,omitempty"`
 
 	// stripe size gte
-	StripeSizeGte *float64 `json:"stripe_size_gte,omitempty"`
+	StripeSizeGte *int64 `json:"stripe_size_gte,omitempty"`
 
 	// stripe size in
-	StripeSizeIn []float64 `json:"stripe_size_in,omitempty"`
+	StripeSizeIn []int64 `json:"stripe_size_in,omitempty"`
 
 	// stripe size lt
-	StripeSizeLt *float64 `json:"stripe_size_lt,omitempty"`
+	StripeSizeLt *int64 `json:"stripe_size_lt,omitempty"`
 
 	// stripe size lte
-	StripeSizeLte *float64 `json:"stripe_size_lte,omitempty"`
+	StripeSizeLte *int64 `json:"stripe_size_lte,omitempty"`
 
 	// stripe size not
-	StripeSizeNot *float64 `json:"stripe_size_not,omitempty"`
+	StripeSizeNot *int64 `json:"stripe_size_not,omitempty"`
 
 	// stripe size not in
-	StripeSizeNotIn []float64 `json:"stripe_size_not_in,omitempty"`
+	StripeSizeNotIn []int64 `json:"stripe_size_not_in,omitempty"`
 
 	// thin provision
 	ThinProvision *bool `json:"thin_provision,omitempty"`

--- a/models/everoute_package.go
+++ b/models/everoute_package.go
@@ -48,7 +48,7 @@ type EveroutePackage struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// upload task
 	UploadTask *NestedUploadTask `json:"upload_task,omitempty"`

--- a/models/everoute_package_where_input.go
+++ b/models/everoute_package_where_input.go
@@ -204,28 +204,28 @@ type EveroutePackageWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// version
 	Version *string `json:"version,omitempty"`

--- a/models/host.go
+++ b/models/host.go
@@ -25,7 +25,7 @@ type Host struct {
 
 	// allocatable memory bytes
 	// Required: true
-	AllocatableMemoryBytes *float64 `json:"allocatable_memory_bytes"`
+	AllocatableMemoryBytes *int64 `json:"allocatable_memory_bytes"`
 
 	// chunk id
 	// Required: true
@@ -52,7 +52,7 @@ type Host struct {
 
 	// cpu hz per core
 	// Required: true
-	CPUHzPerCore *float64 `json:"cpu_hz_per_core"`
+	CPUHzPerCore *int64 `json:"cpu_hz_per_core"`
 
 	// cpu model
 	// Required: true
@@ -70,11 +70,11 @@ type Host struct {
 
 	// failure data space
 	// Required: true
-	FailureDataSpace *float64 `json:"failure_data_space"`
+	FailureDataSpace *int64 `json:"failure_data_space"`
 
 	// hdd data capacity
 	// Required: true
-	HddDataCapacity *float64 `json:"hdd_data_capacity"`
+	HddDataCapacity *int64 `json:"hdd_data_capacity"`
 
 	// hdd disk count
 	// Required: true
@@ -129,14 +129,14 @@ type Host struct {
 
 	// os memory bytes
 	// Required: true
-	OsMemoryBytes *float64 `json:"os_memory_bytes"`
+	OsMemoryBytes *int64 `json:"os_memory_bytes"`
 
 	// os version
 	OsVersion *string `json:"os_version,omitempty"`
 
 	// pmem dimm capacity
 	// Required: true
-	PmemDimmCapacity *float64 `json:"pmem_dimm_capacity"`
+	PmemDimmCapacity *int64 `json:"pmem_dimm_capacity"`
 
 	// pmem dimm count
 	// Required: true
@@ -155,20 +155,20 @@ type Host struct {
 
 	// provisioned memory bytes
 	// Required: true
-	ProvisionedMemoryBytes *float64 `json:"provisioned_memory_bytes"`
+	ProvisionedMemoryBytes *int64 `json:"provisioned_memory_bytes"`
 
 	// running pause vm memory bytes
 	// Required: true
-	RunningPauseVMMemoryBytes *float64 `json:"running_pause_vm_memory_bytes"`
+	RunningPauseVMMemoryBytes *int64 `json:"running_pause_vm_memory_bytes"`
 
 	// running vm num
 	RunningVMNum *int32 `json:"running_vm_num,omitempty"`
 
 	// scvm cpu
-	ScvmCPU *float64 `json:"scvm_cpu,omitempty"`
+	ScvmCPU *int32 `json:"scvm_cpu,omitempty"`
 
 	// scvm memory
-	ScvmMemory *float64 `json:"scvm_memory,omitempty"`
+	ScvmMemory *int64 `json:"scvm_memory,omitempty"`
 
 	// scvm name
 	ScvmName *string `json:"scvm_name,omitempty"`
@@ -178,7 +178,7 @@ type Host struct {
 
 	// ssd data capacity
 	// Required: true
-	SsdDataCapacity *float64 `json:"ssd_data_capacity"`
+	SsdDataCapacity *int64 `json:"ssd_data_capacity"`
 
 	// ssd disk count
 	// Required: true
@@ -199,7 +199,7 @@ type Host struct {
 	SuspendedVMNum *int32 `json:"suspended_vm_num,omitempty"`
 
 	// total cache capacity
-	TotalCacheCapacity *float64 `json:"total_cache_capacity,omitempty"`
+	TotalCacheCapacity *int64 `json:"total_cache_capacity,omitempty"`
 
 	// total cpu cores
 	// Required: true
@@ -207,31 +207,31 @@ type Host struct {
 
 	// total cpu hz
 	// Required: true
-	TotalCPUHz *float64 `json:"total_cpu_hz"`
+	TotalCPUHz *int64 `json:"total_cpu_hz"`
 
 	// total cpu sockets
 	TotalCPUSockets *int32 `json:"total_cpu_sockets,omitempty"`
 
 	// total data capacity
 	// Required: true
-	TotalDataCapacity *float64 `json:"total_data_capacity"`
+	TotalDataCapacity *int64 `json:"total_data_capacity"`
 
 	// total memory bytes
 	// Required: true
-	TotalMemoryBytes *float64 `json:"total_memory_bytes"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes"`
 
 	// usb devices
 	UsbDevices []*NestedUsbDevice `json:"usb_devices,omitempty"`
 
 	// used cpu hz
-	UsedCPUHz *float64 `json:"used_cpu_hz,omitempty"`
+	UsedCPUHz *int64 `json:"used_cpu_hz,omitempty"`
 
 	// used data space
 	// Required: true
-	UsedDataSpace *float64 `json:"used_data_space"`
+	UsedDataSpace *int64 `json:"used_data_space"`
 
 	// used memory bytes
-	UsedMemoryBytes *float64 `json:"used_memory_bytes,omitempty"`
+	UsedMemoryBytes *int64 `json:"used_memory_bytes,omitempty"`
 
 	// vm num
 	VMNum *int32 `json:"vm_num,omitempty"`

--- a/models/host_where_input.go
+++ b/models/host_where_input.go
@@ -72,28 +72,28 @@ type HostWhereInput struct {
 	AccessIPStartsWith *string `json:"access_ip_starts_with,omitempty"`
 
 	// allocatable memory bytes
-	AllocatableMemoryBytes *float64 `json:"allocatable_memory_bytes,omitempty"`
+	AllocatableMemoryBytes *int64 `json:"allocatable_memory_bytes,omitempty"`
 
 	// allocatable memory bytes gt
-	AllocatableMemoryBytesGt *float64 `json:"allocatable_memory_bytes_gt,omitempty"`
+	AllocatableMemoryBytesGt *int64 `json:"allocatable_memory_bytes_gt,omitempty"`
 
 	// allocatable memory bytes gte
-	AllocatableMemoryBytesGte *float64 `json:"allocatable_memory_bytes_gte,omitempty"`
+	AllocatableMemoryBytesGte *int64 `json:"allocatable_memory_bytes_gte,omitempty"`
 
 	// allocatable memory bytes in
-	AllocatableMemoryBytesIn []float64 `json:"allocatable_memory_bytes_in,omitempty"`
+	AllocatableMemoryBytesIn []int64 `json:"allocatable_memory_bytes_in,omitempty"`
 
 	// allocatable memory bytes lt
-	AllocatableMemoryBytesLt *float64 `json:"allocatable_memory_bytes_lt,omitempty"`
+	AllocatableMemoryBytesLt *int64 `json:"allocatable_memory_bytes_lt,omitempty"`
 
 	// allocatable memory bytes lte
-	AllocatableMemoryBytesLte *float64 `json:"allocatable_memory_bytes_lte,omitempty"`
+	AllocatableMemoryBytesLte *int64 `json:"allocatable_memory_bytes_lte,omitempty"`
 
 	// allocatable memory bytes not
-	AllocatableMemoryBytesNot *float64 `json:"allocatable_memory_bytes_not,omitempty"`
+	AllocatableMemoryBytesNot *int64 `json:"allocatable_memory_bytes_not,omitempty"`
 
 	// allocatable memory bytes not in
-	AllocatableMemoryBytesNotIn []float64 `json:"allocatable_memory_bytes_not_in,omitempty"`
+	AllocatableMemoryBytesNotIn []int64 `json:"allocatable_memory_bytes_not_in,omitempty"`
 
 	// chunk id
 	ChunkID *string `json:"chunk_id,omitempty"`
@@ -195,28 +195,28 @@ type HostWhereInput struct {
 	CPUFanSpeedUnitNotIn []CPUFanSpeedUnit `json:"cpu_fan_speed_unit_not_in,omitempty"`
 
 	// cpu hz per core
-	CPUHzPerCore *float64 `json:"cpu_hz_per_core,omitempty"`
+	CPUHzPerCore *int64 `json:"cpu_hz_per_core,omitempty"`
 
 	// cpu hz per core gt
-	CPUHzPerCoreGt *float64 `json:"cpu_hz_per_core_gt,omitempty"`
+	CPUHzPerCoreGt *int64 `json:"cpu_hz_per_core_gt,omitempty"`
 
 	// cpu hz per core gte
-	CPUHzPerCoreGte *float64 `json:"cpu_hz_per_core_gte,omitempty"`
+	CPUHzPerCoreGte *int64 `json:"cpu_hz_per_core_gte,omitempty"`
 
 	// cpu hz per core in
-	CPUHzPerCoreIn []float64 `json:"cpu_hz_per_core_in,omitempty"`
+	CPUHzPerCoreIn []int64 `json:"cpu_hz_per_core_in,omitempty"`
 
 	// cpu hz per core lt
-	CPUHzPerCoreLt *float64 `json:"cpu_hz_per_core_lt,omitempty"`
+	CPUHzPerCoreLt *int64 `json:"cpu_hz_per_core_lt,omitempty"`
 
 	// cpu hz per core lte
-	CPUHzPerCoreLte *float64 `json:"cpu_hz_per_core_lte,omitempty"`
+	CPUHzPerCoreLte *int64 `json:"cpu_hz_per_core_lte,omitempty"`
 
 	// cpu hz per core not
-	CPUHzPerCoreNot *float64 `json:"cpu_hz_per_core_not,omitempty"`
+	CPUHzPerCoreNot *int64 `json:"cpu_hz_per_core_not,omitempty"`
 
 	// cpu hz per core not in
-	CPUHzPerCoreNotIn []float64 `json:"cpu_hz_per_core_not_in,omitempty"`
+	CPUHzPerCoreNotIn []int64 `json:"cpu_hz_per_core_not_in,omitempty"`
 
 	// cpu model
 	CPUModel *string `json:"cpu_model,omitempty"`
@@ -312,52 +312,52 @@ type HostWhereInput struct {
 	DisksSome *DiskWhereInput `json:"disks_some,omitempty"`
 
 	// failure data space
-	FailureDataSpace *float64 `json:"failure_data_space,omitempty"`
+	FailureDataSpace *int64 `json:"failure_data_space,omitempty"`
 
 	// failure data space gt
-	FailureDataSpaceGt *float64 `json:"failure_data_space_gt,omitempty"`
+	FailureDataSpaceGt *int64 `json:"failure_data_space_gt,omitempty"`
 
 	// failure data space gte
-	FailureDataSpaceGte *float64 `json:"failure_data_space_gte,omitempty"`
+	FailureDataSpaceGte *int64 `json:"failure_data_space_gte,omitempty"`
 
 	// failure data space in
-	FailureDataSpaceIn []float64 `json:"failure_data_space_in,omitempty"`
+	FailureDataSpaceIn []int64 `json:"failure_data_space_in,omitempty"`
 
 	// failure data space lt
-	FailureDataSpaceLt *float64 `json:"failure_data_space_lt,omitempty"`
+	FailureDataSpaceLt *int64 `json:"failure_data_space_lt,omitempty"`
 
 	// failure data space lte
-	FailureDataSpaceLte *float64 `json:"failure_data_space_lte,omitempty"`
+	FailureDataSpaceLte *int64 `json:"failure_data_space_lte,omitempty"`
 
 	// failure data space not
-	FailureDataSpaceNot *float64 `json:"failure_data_space_not,omitempty"`
+	FailureDataSpaceNot *int64 `json:"failure_data_space_not,omitempty"`
 
 	// failure data space not in
-	FailureDataSpaceNotIn []float64 `json:"failure_data_space_not_in,omitempty"`
+	FailureDataSpaceNotIn []int64 `json:"failure_data_space_not_in,omitempty"`
 
 	// hdd data capacity
-	HddDataCapacity *float64 `json:"hdd_data_capacity,omitempty"`
+	HddDataCapacity *int64 `json:"hdd_data_capacity,omitempty"`
 
 	// hdd data capacity gt
-	HddDataCapacityGt *float64 `json:"hdd_data_capacity_gt,omitempty"`
+	HddDataCapacityGt *int64 `json:"hdd_data_capacity_gt,omitempty"`
 
 	// hdd data capacity gte
-	HddDataCapacityGte *float64 `json:"hdd_data_capacity_gte,omitempty"`
+	HddDataCapacityGte *int64 `json:"hdd_data_capacity_gte,omitempty"`
 
 	// hdd data capacity in
-	HddDataCapacityIn []float64 `json:"hdd_data_capacity_in,omitempty"`
+	HddDataCapacityIn []int64 `json:"hdd_data_capacity_in,omitempty"`
 
 	// hdd data capacity lt
-	HddDataCapacityLt *float64 `json:"hdd_data_capacity_lt,omitempty"`
+	HddDataCapacityLt *int64 `json:"hdd_data_capacity_lt,omitempty"`
 
 	// hdd data capacity lte
-	HddDataCapacityLte *float64 `json:"hdd_data_capacity_lte,omitempty"`
+	HddDataCapacityLte *int64 `json:"hdd_data_capacity_lte,omitempty"`
 
 	// hdd data capacity not
-	HddDataCapacityNot *float64 `json:"hdd_data_capacity_not,omitempty"`
+	HddDataCapacityNot *int64 `json:"hdd_data_capacity_not,omitempty"`
 
 	// hdd data capacity not in
-	HddDataCapacityNotIn []float64 `json:"hdd_data_capacity_not_in,omitempty"`
+	HddDataCapacityNotIn []int64 `json:"hdd_data_capacity_not_in,omitempty"`
 
 	// hdd disk count
 	HddDiskCount *int32 `json:"hdd_disk_count,omitempty"`
@@ -699,28 +699,28 @@ type HostWhereInput struct {
 	NodeTopoLocalIDStartsWith *string `json:"node_topo_local_id_starts_with,omitempty"`
 
 	// os memory bytes
-	OsMemoryBytes *float64 `json:"os_memory_bytes,omitempty"`
+	OsMemoryBytes *int64 `json:"os_memory_bytes,omitempty"`
 
 	// os memory bytes gt
-	OsMemoryBytesGt *float64 `json:"os_memory_bytes_gt,omitempty"`
+	OsMemoryBytesGt *int64 `json:"os_memory_bytes_gt,omitempty"`
 
 	// os memory bytes gte
-	OsMemoryBytesGte *float64 `json:"os_memory_bytes_gte,omitempty"`
+	OsMemoryBytesGte *int64 `json:"os_memory_bytes_gte,omitempty"`
 
 	// os memory bytes in
-	OsMemoryBytesIn []float64 `json:"os_memory_bytes_in,omitempty"`
+	OsMemoryBytesIn []int64 `json:"os_memory_bytes_in,omitempty"`
 
 	// os memory bytes lt
-	OsMemoryBytesLt *float64 `json:"os_memory_bytes_lt,omitempty"`
+	OsMemoryBytesLt *int64 `json:"os_memory_bytes_lt,omitempty"`
 
 	// os memory bytes lte
-	OsMemoryBytesLte *float64 `json:"os_memory_bytes_lte,omitempty"`
+	OsMemoryBytesLte *int64 `json:"os_memory_bytes_lte,omitempty"`
 
 	// os memory bytes not
-	OsMemoryBytesNot *float64 `json:"os_memory_bytes_not,omitempty"`
+	OsMemoryBytesNot *int64 `json:"os_memory_bytes_not,omitempty"`
 
 	// os memory bytes not in
-	OsMemoryBytesNotIn []float64 `json:"os_memory_bytes_not_in,omitempty"`
+	OsMemoryBytesNotIn []int64 `json:"os_memory_bytes_not_in,omitempty"`
 
 	// os version
 	OsVersion *string `json:"os_version,omitempty"`
@@ -765,28 +765,28 @@ type HostWhereInput struct {
 	OsVersionStartsWith *string `json:"os_version_starts_with,omitempty"`
 
 	// pmem dimm capacity
-	PmemDimmCapacity *float64 `json:"pmem_dimm_capacity,omitempty"`
+	PmemDimmCapacity *int64 `json:"pmem_dimm_capacity,omitempty"`
 
 	// pmem dimm capacity gt
-	PmemDimmCapacityGt *float64 `json:"pmem_dimm_capacity_gt,omitempty"`
+	PmemDimmCapacityGt *int64 `json:"pmem_dimm_capacity_gt,omitempty"`
 
 	// pmem dimm capacity gte
-	PmemDimmCapacityGte *float64 `json:"pmem_dimm_capacity_gte,omitempty"`
+	PmemDimmCapacityGte *int64 `json:"pmem_dimm_capacity_gte,omitempty"`
 
 	// pmem dimm capacity in
-	PmemDimmCapacityIn []float64 `json:"pmem_dimm_capacity_in,omitempty"`
+	PmemDimmCapacityIn []int64 `json:"pmem_dimm_capacity_in,omitempty"`
 
 	// pmem dimm capacity lt
-	PmemDimmCapacityLt *float64 `json:"pmem_dimm_capacity_lt,omitempty"`
+	PmemDimmCapacityLt *int64 `json:"pmem_dimm_capacity_lt,omitempty"`
 
 	// pmem dimm capacity lte
-	PmemDimmCapacityLte *float64 `json:"pmem_dimm_capacity_lte,omitempty"`
+	PmemDimmCapacityLte *int64 `json:"pmem_dimm_capacity_lte,omitempty"`
 
 	// pmem dimm capacity not
-	PmemDimmCapacityNot *float64 `json:"pmem_dimm_capacity_not,omitempty"`
+	PmemDimmCapacityNot *int64 `json:"pmem_dimm_capacity_not,omitempty"`
 
 	// pmem dimm capacity not in
-	PmemDimmCapacityNotIn []float64 `json:"pmem_dimm_capacity_not_in,omitempty"`
+	PmemDimmCapacityNotIn []int64 `json:"pmem_dimm_capacity_not_in,omitempty"`
 
 	// pmem dimm count
 	PmemDimmCount *int32 `json:"pmem_dimm_count,omitempty"`
@@ -870,52 +870,52 @@ type HostWhereInput struct {
 	ProvisionedCPUCoresNotIn []int32 `json:"provisioned_cpu_cores_not_in,omitempty"`
 
 	// provisioned memory bytes
-	ProvisionedMemoryBytes *float64 `json:"provisioned_memory_bytes,omitempty"`
+	ProvisionedMemoryBytes *int64 `json:"provisioned_memory_bytes,omitempty"`
 
 	// provisioned memory bytes gt
-	ProvisionedMemoryBytesGt *float64 `json:"provisioned_memory_bytes_gt,omitempty"`
+	ProvisionedMemoryBytesGt *int64 `json:"provisioned_memory_bytes_gt,omitempty"`
 
 	// provisioned memory bytes gte
-	ProvisionedMemoryBytesGte *float64 `json:"provisioned_memory_bytes_gte,omitempty"`
+	ProvisionedMemoryBytesGte *int64 `json:"provisioned_memory_bytes_gte,omitempty"`
 
 	// provisioned memory bytes in
-	ProvisionedMemoryBytesIn []float64 `json:"provisioned_memory_bytes_in,omitempty"`
+	ProvisionedMemoryBytesIn []int64 `json:"provisioned_memory_bytes_in,omitempty"`
 
 	// provisioned memory bytes lt
-	ProvisionedMemoryBytesLt *float64 `json:"provisioned_memory_bytes_lt,omitempty"`
+	ProvisionedMemoryBytesLt *int64 `json:"provisioned_memory_bytes_lt,omitempty"`
 
 	// provisioned memory bytes lte
-	ProvisionedMemoryBytesLte *float64 `json:"provisioned_memory_bytes_lte,omitempty"`
+	ProvisionedMemoryBytesLte *int64 `json:"provisioned_memory_bytes_lte,omitempty"`
 
 	// provisioned memory bytes not
-	ProvisionedMemoryBytesNot *float64 `json:"provisioned_memory_bytes_not,omitempty"`
+	ProvisionedMemoryBytesNot *int64 `json:"provisioned_memory_bytes_not,omitempty"`
 
 	// provisioned memory bytes not in
-	ProvisionedMemoryBytesNotIn []float64 `json:"provisioned_memory_bytes_not_in,omitempty"`
+	ProvisionedMemoryBytesNotIn []int64 `json:"provisioned_memory_bytes_not_in,omitempty"`
 
 	// running pause vm memory bytes
-	RunningPauseVMMemoryBytes *float64 `json:"running_pause_vm_memory_bytes,omitempty"`
+	RunningPauseVMMemoryBytes *int64 `json:"running_pause_vm_memory_bytes,omitempty"`
 
 	// running pause vm memory bytes gt
-	RunningPauseVMMemoryBytesGt *float64 `json:"running_pause_vm_memory_bytes_gt,omitempty"`
+	RunningPauseVMMemoryBytesGt *int64 `json:"running_pause_vm_memory_bytes_gt,omitempty"`
 
 	// running pause vm memory bytes gte
-	RunningPauseVMMemoryBytesGte *float64 `json:"running_pause_vm_memory_bytes_gte,omitempty"`
+	RunningPauseVMMemoryBytesGte *int64 `json:"running_pause_vm_memory_bytes_gte,omitempty"`
 
 	// running pause vm memory bytes in
-	RunningPauseVMMemoryBytesIn []float64 `json:"running_pause_vm_memory_bytes_in,omitempty"`
+	RunningPauseVMMemoryBytesIn []int64 `json:"running_pause_vm_memory_bytes_in,omitempty"`
 
 	// running pause vm memory bytes lt
-	RunningPauseVMMemoryBytesLt *float64 `json:"running_pause_vm_memory_bytes_lt,omitempty"`
+	RunningPauseVMMemoryBytesLt *int64 `json:"running_pause_vm_memory_bytes_lt,omitempty"`
 
 	// running pause vm memory bytes lte
-	RunningPauseVMMemoryBytesLte *float64 `json:"running_pause_vm_memory_bytes_lte,omitempty"`
+	RunningPauseVMMemoryBytesLte *int64 `json:"running_pause_vm_memory_bytes_lte,omitempty"`
 
 	// running pause vm memory bytes not
-	RunningPauseVMMemoryBytesNot *float64 `json:"running_pause_vm_memory_bytes_not,omitempty"`
+	RunningPauseVMMemoryBytesNot *int64 `json:"running_pause_vm_memory_bytes_not,omitempty"`
 
 	// running pause vm memory bytes not in
-	RunningPauseVMMemoryBytesNotIn []float64 `json:"running_pause_vm_memory_bytes_not_in,omitempty"`
+	RunningPauseVMMemoryBytesNotIn []int64 `json:"running_pause_vm_memory_bytes_not_in,omitempty"`
 
 	// running vm num
 	RunningVMNum *int32 `json:"running_vm_num,omitempty"`
@@ -942,52 +942,52 @@ type HostWhereInput struct {
 	RunningVMNumNotIn []int32 `json:"running_vm_num_not_in,omitempty"`
 
 	// scvm cpu
-	ScvmCPU *float64 `json:"scvm_cpu,omitempty"`
+	ScvmCPU *int32 `json:"scvm_cpu,omitempty"`
 
 	// scvm cpu gt
-	ScvmCPUGt *float64 `json:"scvm_cpu_gt,omitempty"`
+	ScvmCPUGt *int32 `json:"scvm_cpu_gt,omitempty"`
 
 	// scvm cpu gte
-	ScvmCPUGte *float64 `json:"scvm_cpu_gte,omitempty"`
+	ScvmCPUGte *int32 `json:"scvm_cpu_gte,omitempty"`
 
 	// scvm cpu in
-	ScvmCPUIn []float64 `json:"scvm_cpu_in,omitempty"`
+	ScvmCPUIn []int32 `json:"scvm_cpu_in,omitempty"`
 
 	// scvm cpu lt
-	ScvmCPULt *float64 `json:"scvm_cpu_lt,omitempty"`
+	ScvmCPULt *int32 `json:"scvm_cpu_lt,omitempty"`
 
 	// scvm cpu lte
-	ScvmCPULte *float64 `json:"scvm_cpu_lte,omitempty"`
+	ScvmCPULte *int32 `json:"scvm_cpu_lte,omitempty"`
 
 	// scvm cpu not
-	ScvmCPUNot *float64 `json:"scvm_cpu_not,omitempty"`
+	ScvmCPUNot *int32 `json:"scvm_cpu_not,omitempty"`
 
 	// scvm cpu not in
-	ScvmCPUNotIn []float64 `json:"scvm_cpu_not_in,omitempty"`
+	ScvmCPUNotIn []int32 `json:"scvm_cpu_not_in,omitempty"`
 
 	// scvm memory
-	ScvmMemory *float64 `json:"scvm_memory,omitempty"`
+	ScvmMemory *int64 `json:"scvm_memory,omitempty"`
 
 	// scvm memory gt
-	ScvmMemoryGt *float64 `json:"scvm_memory_gt,omitempty"`
+	ScvmMemoryGt *int64 `json:"scvm_memory_gt,omitempty"`
 
 	// scvm memory gte
-	ScvmMemoryGte *float64 `json:"scvm_memory_gte,omitempty"`
+	ScvmMemoryGte *int64 `json:"scvm_memory_gte,omitempty"`
 
 	// scvm memory in
-	ScvmMemoryIn []float64 `json:"scvm_memory_in,omitempty"`
+	ScvmMemoryIn []int64 `json:"scvm_memory_in,omitempty"`
 
 	// scvm memory lt
-	ScvmMemoryLt *float64 `json:"scvm_memory_lt,omitempty"`
+	ScvmMemoryLt *int64 `json:"scvm_memory_lt,omitempty"`
 
 	// scvm memory lte
-	ScvmMemoryLte *float64 `json:"scvm_memory_lte,omitempty"`
+	ScvmMemoryLte *int64 `json:"scvm_memory_lte,omitempty"`
 
 	// scvm memory not
-	ScvmMemoryNot *float64 `json:"scvm_memory_not,omitempty"`
+	ScvmMemoryNot *int64 `json:"scvm_memory_not,omitempty"`
 
 	// scvm memory not in
-	ScvmMemoryNotIn []float64 `json:"scvm_memory_not_in,omitempty"`
+	ScvmMemoryNotIn []int64 `json:"scvm_memory_not_in,omitempty"`
 
 	// scvm name
 	ScvmName *string `json:"scvm_name,omitempty"`
@@ -1074,28 +1074,28 @@ type HostWhereInput struct {
 	SerialStartsWith *string `json:"serial_starts_with,omitempty"`
 
 	// ssd data capacity
-	SsdDataCapacity *float64 `json:"ssd_data_capacity,omitempty"`
+	SsdDataCapacity *int64 `json:"ssd_data_capacity,omitempty"`
 
 	// ssd data capacity gt
-	SsdDataCapacityGt *float64 `json:"ssd_data_capacity_gt,omitempty"`
+	SsdDataCapacityGt *int64 `json:"ssd_data_capacity_gt,omitempty"`
 
 	// ssd data capacity gte
-	SsdDataCapacityGte *float64 `json:"ssd_data_capacity_gte,omitempty"`
+	SsdDataCapacityGte *int64 `json:"ssd_data_capacity_gte,omitempty"`
 
 	// ssd data capacity in
-	SsdDataCapacityIn []float64 `json:"ssd_data_capacity_in,omitempty"`
+	SsdDataCapacityIn []int64 `json:"ssd_data_capacity_in,omitempty"`
 
 	// ssd data capacity lt
-	SsdDataCapacityLt *float64 `json:"ssd_data_capacity_lt,omitempty"`
+	SsdDataCapacityLt *int64 `json:"ssd_data_capacity_lt,omitempty"`
 
 	// ssd data capacity lte
-	SsdDataCapacityLte *float64 `json:"ssd_data_capacity_lte,omitempty"`
+	SsdDataCapacityLte *int64 `json:"ssd_data_capacity_lte,omitempty"`
 
 	// ssd data capacity not
-	SsdDataCapacityNot *float64 `json:"ssd_data_capacity_not,omitempty"`
+	SsdDataCapacityNot *int64 `json:"ssd_data_capacity_not,omitempty"`
 
 	// ssd data capacity not in
-	SsdDataCapacityNotIn []float64 `json:"ssd_data_capacity_not_in,omitempty"`
+	SsdDataCapacityNotIn []int64 `json:"ssd_data_capacity_not_in,omitempty"`
 
 	// ssd disk count
 	SsdDiskCount *int32 `json:"ssd_disk_count,omitempty"`
@@ -1194,28 +1194,28 @@ type HostWhereInput struct {
 	SuspendedVMNumNotIn []int32 `json:"suspended_vm_num_not_in,omitempty"`
 
 	// total cache capacity
-	TotalCacheCapacity *float64 `json:"total_cache_capacity,omitempty"`
+	TotalCacheCapacity *int64 `json:"total_cache_capacity,omitempty"`
 
 	// total cache capacity gt
-	TotalCacheCapacityGt *float64 `json:"total_cache_capacity_gt,omitempty"`
+	TotalCacheCapacityGt *int64 `json:"total_cache_capacity_gt,omitempty"`
 
 	// total cache capacity gte
-	TotalCacheCapacityGte *float64 `json:"total_cache_capacity_gte,omitempty"`
+	TotalCacheCapacityGte *int64 `json:"total_cache_capacity_gte,omitempty"`
 
 	// total cache capacity in
-	TotalCacheCapacityIn []float64 `json:"total_cache_capacity_in,omitempty"`
+	TotalCacheCapacityIn []int64 `json:"total_cache_capacity_in,omitempty"`
 
 	// total cache capacity lt
-	TotalCacheCapacityLt *float64 `json:"total_cache_capacity_lt,omitempty"`
+	TotalCacheCapacityLt *int64 `json:"total_cache_capacity_lt,omitempty"`
 
 	// total cache capacity lte
-	TotalCacheCapacityLte *float64 `json:"total_cache_capacity_lte,omitempty"`
+	TotalCacheCapacityLte *int64 `json:"total_cache_capacity_lte,omitempty"`
 
 	// total cache capacity not
-	TotalCacheCapacityNot *float64 `json:"total_cache_capacity_not,omitempty"`
+	TotalCacheCapacityNot *int64 `json:"total_cache_capacity_not,omitempty"`
 
 	// total cache capacity not in
-	TotalCacheCapacityNotIn []float64 `json:"total_cache_capacity_not_in,omitempty"`
+	TotalCacheCapacityNotIn []int64 `json:"total_cache_capacity_not_in,omitempty"`
 
 	// total cpu cores
 	TotalCPUCores *int32 `json:"total_cpu_cores,omitempty"`
@@ -1242,28 +1242,28 @@ type HostWhereInput struct {
 	TotalCPUCoresNotIn []int32 `json:"total_cpu_cores_not_in,omitempty"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total cpu hz gt
-	TotalCPUHzGt *float64 `json:"total_cpu_hz_gt,omitempty"`
+	TotalCPUHzGt *int64 `json:"total_cpu_hz_gt,omitempty"`
 
 	// total cpu hz gte
-	TotalCPUHzGte *float64 `json:"total_cpu_hz_gte,omitempty"`
+	TotalCPUHzGte *int64 `json:"total_cpu_hz_gte,omitempty"`
 
 	// total cpu hz in
-	TotalCPUHzIn []float64 `json:"total_cpu_hz_in,omitempty"`
+	TotalCPUHzIn []int64 `json:"total_cpu_hz_in,omitempty"`
 
 	// total cpu hz lt
-	TotalCPUHzLt *float64 `json:"total_cpu_hz_lt,omitempty"`
+	TotalCPUHzLt *int64 `json:"total_cpu_hz_lt,omitempty"`
 
 	// total cpu hz lte
-	TotalCPUHzLte *float64 `json:"total_cpu_hz_lte,omitempty"`
+	TotalCPUHzLte *int64 `json:"total_cpu_hz_lte,omitempty"`
 
 	// total cpu hz not
-	TotalCPUHzNot *float64 `json:"total_cpu_hz_not,omitempty"`
+	TotalCPUHzNot *int64 `json:"total_cpu_hz_not,omitempty"`
 
 	// total cpu hz not in
-	TotalCPUHzNotIn []float64 `json:"total_cpu_hz_not_in,omitempty"`
+	TotalCPUHzNotIn []int64 `json:"total_cpu_hz_not_in,omitempty"`
 
 	// total cpu sockets
 	TotalCPUSockets *int32 `json:"total_cpu_sockets,omitempty"`
@@ -1290,52 +1290,52 @@ type HostWhereInput struct {
 	TotalCPUSocketsNotIn []int32 `json:"total_cpu_sockets_not_in,omitempty"`
 
 	// total data capacity
-	TotalDataCapacity *float64 `json:"total_data_capacity,omitempty"`
+	TotalDataCapacity *int64 `json:"total_data_capacity,omitempty"`
 
 	// total data capacity gt
-	TotalDataCapacityGt *float64 `json:"total_data_capacity_gt,omitempty"`
+	TotalDataCapacityGt *int64 `json:"total_data_capacity_gt,omitempty"`
 
 	// total data capacity gte
-	TotalDataCapacityGte *float64 `json:"total_data_capacity_gte,omitempty"`
+	TotalDataCapacityGte *int64 `json:"total_data_capacity_gte,omitempty"`
 
 	// total data capacity in
-	TotalDataCapacityIn []float64 `json:"total_data_capacity_in,omitempty"`
+	TotalDataCapacityIn []int64 `json:"total_data_capacity_in,omitempty"`
 
 	// total data capacity lt
-	TotalDataCapacityLt *float64 `json:"total_data_capacity_lt,omitempty"`
+	TotalDataCapacityLt *int64 `json:"total_data_capacity_lt,omitempty"`
 
 	// total data capacity lte
-	TotalDataCapacityLte *float64 `json:"total_data_capacity_lte,omitempty"`
+	TotalDataCapacityLte *int64 `json:"total_data_capacity_lte,omitempty"`
 
 	// total data capacity not
-	TotalDataCapacityNot *float64 `json:"total_data_capacity_not,omitempty"`
+	TotalDataCapacityNot *int64 `json:"total_data_capacity_not,omitempty"`
 
 	// total data capacity not in
-	TotalDataCapacityNotIn []float64 `json:"total_data_capacity_not_in,omitempty"`
+	TotalDataCapacityNotIn []int64 `json:"total_data_capacity_not_in,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// total memory bytes gt
-	TotalMemoryBytesGt *float64 `json:"total_memory_bytes_gt,omitempty"`
+	TotalMemoryBytesGt *int64 `json:"total_memory_bytes_gt,omitempty"`
 
 	// total memory bytes gte
-	TotalMemoryBytesGte *float64 `json:"total_memory_bytes_gte,omitempty"`
+	TotalMemoryBytesGte *int64 `json:"total_memory_bytes_gte,omitempty"`
 
 	// total memory bytes in
-	TotalMemoryBytesIn []float64 `json:"total_memory_bytes_in,omitempty"`
+	TotalMemoryBytesIn []int64 `json:"total_memory_bytes_in,omitempty"`
 
 	// total memory bytes lt
-	TotalMemoryBytesLt *float64 `json:"total_memory_bytes_lt,omitempty"`
+	TotalMemoryBytesLt *int64 `json:"total_memory_bytes_lt,omitempty"`
 
 	// total memory bytes lte
-	TotalMemoryBytesLte *float64 `json:"total_memory_bytes_lte,omitempty"`
+	TotalMemoryBytesLte *int64 `json:"total_memory_bytes_lte,omitempty"`
 
 	// total memory bytes not
-	TotalMemoryBytesNot *float64 `json:"total_memory_bytes_not,omitempty"`
+	TotalMemoryBytesNot *int64 `json:"total_memory_bytes_not,omitempty"`
 
 	// total memory bytes not in
-	TotalMemoryBytesNotIn []float64 `json:"total_memory_bytes_not_in,omitempty"`
+	TotalMemoryBytesNotIn []int64 `json:"total_memory_bytes_not_in,omitempty"`
 
 	// usb devices every
 	UsbDevicesEvery *UsbDeviceWhereInput `json:"usb_devices_every,omitempty"`
@@ -1347,76 +1347,76 @@ type HostWhereInput struct {
 	UsbDevicesSome *UsbDeviceWhereInput `json:"usb_devices_some,omitempty"`
 
 	// used cpu hz
-	UsedCPUHz *float64 `json:"used_cpu_hz,omitempty"`
+	UsedCPUHz *int64 `json:"used_cpu_hz,omitempty"`
 
 	// used cpu hz gt
-	UsedCPUHzGt *float64 `json:"used_cpu_hz_gt,omitempty"`
+	UsedCPUHzGt *int64 `json:"used_cpu_hz_gt,omitempty"`
 
 	// used cpu hz gte
-	UsedCPUHzGte *float64 `json:"used_cpu_hz_gte,omitempty"`
+	UsedCPUHzGte *int64 `json:"used_cpu_hz_gte,omitempty"`
 
 	// used cpu hz in
-	UsedCPUHzIn []float64 `json:"used_cpu_hz_in,omitempty"`
+	UsedCPUHzIn []int64 `json:"used_cpu_hz_in,omitempty"`
 
 	// used cpu hz lt
-	UsedCPUHzLt *float64 `json:"used_cpu_hz_lt,omitempty"`
+	UsedCPUHzLt *int64 `json:"used_cpu_hz_lt,omitempty"`
 
 	// used cpu hz lte
-	UsedCPUHzLte *float64 `json:"used_cpu_hz_lte,omitempty"`
+	UsedCPUHzLte *int64 `json:"used_cpu_hz_lte,omitempty"`
 
 	// used cpu hz not
-	UsedCPUHzNot *float64 `json:"used_cpu_hz_not,omitempty"`
+	UsedCPUHzNot *int64 `json:"used_cpu_hz_not,omitempty"`
 
 	// used cpu hz not in
-	UsedCPUHzNotIn []float64 `json:"used_cpu_hz_not_in,omitempty"`
+	UsedCPUHzNotIn []int64 `json:"used_cpu_hz_not_in,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// used data space gt
-	UsedDataSpaceGt *float64 `json:"used_data_space_gt,omitempty"`
+	UsedDataSpaceGt *int64 `json:"used_data_space_gt,omitempty"`
 
 	// used data space gte
-	UsedDataSpaceGte *float64 `json:"used_data_space_gte,omitempty"`
+	UsedDataSpaceGte *int64 `json:"used_data_space_gte,omitempty"`
 
 	// used data space in
-	UsedDataSpaceIn []float64 `json:"used_data_space_in,omitempty"`
+	UsedDataSpaceIn []int64 `json:"used_data_space_in,omitempty"`
 
 	// used data space lt
-	UsedDataSpaceLt *float64 `json:"used_data_space_lt,omitempty"`
+	UsedDataSpaceLt *int64 `json:"used_data_space_lt,omitempty"`
 
 	// used data space lte
-	UsedDataSpaceLte *float64 `json:"used_data_space_lte,omitempty"`
+	UsedDataSpaceLte *int64 `json:"used_data_space_lte,omitempty"`
 
 	// used data space not
-	UsedDataSpaceNot *float64 `json:"used_data_space_not,omitempty"`
+	UsedDataSpaceNot *int64 `json:"used_data_space_not,omitempty"`
 
 	// used data space not in
-	UsedDataSpaceNotIn []float64 `json:"used_data_space_not_in,omitempty"`
+	UsedDataSpaceNotIn []int64 `json:"used_data_space_not_in,omitempty"`
 
 	// used memory bytes
-	UsedMemoryBytes *float64 `json:"used_memory_bytes,omitempty"`
+	UsedMemoryBytes *int64 `json:"used_memory_bytes,omitempty"`
 
 	// used memory bytes gt
-	UsedMemoryBytesGt *float64 `json:"used_memory_bytes_gt,omitempty"`
+	UsedMemoryBytesGt *int64 `json:"used_memory_bytes_gt,omitempty"`
 
 	// used memory bytes gte
-	UsedMemoryBytesGte *float64 `json:"used_memory_bytes_gte,omitempty"`
+	UsedMemoryBytesGte *int64 `json:"used_memory_bytes_gte,omitempty"`
 
 	// used memory bytes in
-	UsedMemoryBytesIn []float64 `json:"used_memory_bytes_in,omitempty"`
+	UsedMemoryBytesIn []int64 `json:"used_memory_bytes_in,omitempty"`
 
 	// used memory bytes lt
-	UsedMemoryBytesLt *float64 `json:"used_memory_bytes_lt,omitempty"`
+	UsedMemoryBytesLt *int64 `json:"used_memory_bytes_lt,omitempty"`
 
 	// used memory bytes lte
-	UsedMemoryBytesLte *float64 `json:"used_memory_bytes_lte,omitempty"`
+	UsedMemoryBytesLte *int64 `json:"used_memory_bytes_lte,omitempty"`
 
 	// used memory bytes not
-	UsedMemoryBytesNot *float64 `json:"used_memory_bytes_not,omitempty"`
+	UsedMemoryBytesNot *int64 `json:"used_memory_bytes_not,omitempty"`
 
 	// used memory bytes not in
-	UsedMemoryBytesNotIn []float64 `json:"used_memory_bytes_not_in,omitempty"`
+	UsedMemoryBytesNotIn []int64 `json:"used_memory_bytes_not_in,omitempty"`
 
 	// vm num
 	VMNum *int32 `json:"vm_num,omitempty"`

--- a/models/iscsi_lun.go
+++ b/models/iscsi_lun.go
@@ -26,43 +26,43 @@ type IscsiLun struct {
 
 	// assigned size
 	// Required: true
-	AssignedSize *float64 `json:"assigned_size"`
+	AssignedSize *int64 `json:"assigned_size"`
 
 	// bps
 	// Required: true
-	Bps *float64 `json:"bps"`
+	Bps *int64 `json:"bps"`
 
 	// bps max
 	// Required: true
-	BpsMax *float64 `json:"bps_max"`
+	BpsMax *int64 `json:"bps_max"`
 
 	// bps max length
 	// Required: true
-	BpsMaxLength *float64 `json:"bps_max_length"`
+	BpsMaxLength *int64 `json:"bps_max_length"`
 
 	// bps rd
 	// Required: true
-	BpsRd *float64 `json:"bps_rd"`
+	BpsRd *int64 `json:"bps_rd"`
 
 	// bps rd max
 	// Required: true
-	BpsRdMax *float64 `json:"bps_rd_max"`
+	BpsRdMax *int64 `json:"bps_rd_max"`
 
 	// bps rd max length
 	// Required: true
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length"`
 
 	// bps wr
 	// Required: true
-	BpsWr *float64 `json:"bps_wr"`
+	BpsWr *int64 `json:"bps_wr"`
 
 	// bps wr max
 	// Required: true
-	BpsWrMax *float64 `json:"bps_wr_max"`
+	BpsWrMax *int64 `json:"bps_wr_max"`
 
 	// bps wr max length
 	// Required: true
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length"`
 
 	// consistency group
 	ConsistencyGroup *NestedConsistencyGroup `json:"consistency_group,omitempty"`
@@ -76,43 +76,43 @@ type IscsiLun struct {
 
 	// io size
 	// Required: true
-	IoSize *float64 `json:"io_size"`
+	IoSize *int64 `json:"io_size"`
 
 	// iops
 	// Required: true
-	Iops *float64 `json:"iops"`
+	Iops *int64 `json:"iops"`
 
 	// iops max
 	// Required: true
-	IopsMax *float64 `json:"iops_max"`
+	IopsMax *int64 `json:"iops_max"`
 
 	// iops max length
 	// Required: true
-	IopsMaxLength *float64 `json:"iops_max_length"`
+	IopsMaxLength *int64 `json:"iops_max_length"`
 
 	// iops rd
 	// Required: true
-	IopsRd *float64 `json:"iops_rd"`
+	IopsRd *int64 `json:"iops_rd"`
 
 	// iops rd max
 	// Required: true
-	IopsRdMax *float64 `json:"iops_rd_max"`
+	IopsRdMax *int64 `json:"iops_rd_max"`
 
 	// iops rd max length
 	// Required: true
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length"`
 
 	// iops wr
 	// Required: true
-	IopsWr *float64 `json:"iops_wr"`
+	IopsWr *int64 `json:"iops_wr"`
 
 	// iops wr max
 	// Required: true
-	IopsWrMax *float64 `json:"iops_wr_max"`
+	IopsWrMax *int64 `json:"iops_wr_max"`
 
 	// iops wr max length
 	// Required: true
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length"`
 
 	// iscsi target
 	// Required: true
@@ -143,7 +143,7 @@ type IscsiLun struct {
 
 	// shared size
 	// Required: true
-	SharedSize *float64 `json:"shared_size"`
+	SharedSize *int64 `json:"shared_size"`
 
 	// snapshot num
 	// Required: true
@@ -155,7 +155,7 @@ type IscsiLun struct {
 
 	// stripe size
 	// Required: true
-	StripeSize *float64 `json:"stripe_size"`
+	StripeSize *int64 `json:"stripe_size"`
 
 	// thin provision
 	// Required: true
@@ -163,7 +163,7 @@ type IscsiLun struct {
 
 	// unique size
 	// Required: true
-	UniqueSize *float64 `json:"unique_size"`
+	UniqueSize *int64 `json:"unique_size"`
 
 	// zbs volume id
 	// Required: true

--- a/models/iscsi_lun_common_params.go
+++ b/models/iscsi_lun_common_params.go
@@ -21,58 +21,58 @@ type IscsiLunCommonParams struct {
 	AllowedInitiators *string `json:"allowed_initiators,omitempty"`
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 }
 
 // Validate validates this iscsi lun common params

--- a/models/iscsi_lun_creation_params.go
+++ b/models/iscsi_lun_creation_params.go
@@ -21,7 +21,7 @@ type IscsiLunCreationParams struct {
 
 	// assigned size
 	// Required: true
-	AssignedSize *float64 `json:"assigned_size"`
+	AssignedSize *int64 `json:"assigned_size"`
 
 	// iscsi target id
 	// Required: true
@@ -45,7 +45,7 @@ type IscsiLunCreationParams struct {
 func (m *IscsiLunCreationParams) UnmarshalJSON(raw []byte) error {
 	// AO0
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size"`
+		AssignedSize *int64 `json:"assigned_size"`
 
 		IscsiTargetID *string `json:"iscsi_target_id"`
 
@@ -84,7 +84,7 @@ func (m IscsiLunCreationParams) MarshalJSON() ([]byte, error) {
 	_parts := make([][]byte, 0, 2)
 
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size"`
+		AssignedSize *int64 `json:"assigned_size"`
 
 		IscsiTargetID *string `json:"iscsi_target_id"`
 

--- a/models/iscsi_lun_snapshot.go
+++ b/models/iscsi_lun_snapshot.go
@@ -54,7 +54,7 @@ type IscsiLunSnapshot struct {
 
 	// unique size
 	// Required: true
-	UniqueSize *float64 `json:"unique_size"`
+	UniqueSize *int64 `json:"unique_size"`
 }
 
 // Validate validates this iscsi lun snapshot

--- a/models/iscsi_lun_snapshot_where_input.go
+++ b/models/iscsi_lun_snapshot_where_input.go
@@ -210,28 +210,28 @@ type IscsiLunSnapshotWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 }
 
 // Validate validates this iscsi lun snapshot where input

--- a/models/iscsi_lun_updation_params_data.go
+++ b/models/iscsi_lun_updation_params_data.go
@@ -19,7 +19,7 @@ import (
 type IscsiLunUpdationParamsData struct {
 
 	// assigned size
-	AssignedSize *float64 `json:"assigned_size,omitempty"`
+	AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`
@@ -31,7 +31,7 @@ type IscsiLunUpdationParamsData struct {
 func (m *IscsiLunUpdationParamsData) UnmarshalJSON(raw []byte) error {
 	// AO0
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size,omitempty"`
+		AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 		Name *string `json:"name,omitempty"`
 	}
@@ -58,7 +58,7 @@ func (m IscsiLunUpdationParamsData) MarshalJSON() ([]byte, error) {
 	_parts := make([][]byte, 0, 2)
 
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size,omitempty"`
+		AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 		Name *string `json:"name,omitempty"`
 	}

--- a/models/iscsi_lun_where_input.go
+++ b/models/iscsi_lun_where_input.go
@@ -72,244 +72,244 @@ type IscsiLunWhereInput struct {
 	AllowedInitiatorsStartsWith *string `json:"allowed_initiators_starts_with,omitempty"`
 
 	// assigned size
-	AssignedSize *float64 `json:"assigned_size,omitempty"`
+	AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 	// assigned size gt
-	AssignedSizeGt *float64 `json:"assigned_size_gt,omitempty"`
+	AssignedSizeGt *int64 `json:"assigned_size_gt,omitempty"`
 
 	// assigned size gte
-	AssignedSizeGte *float64 `json:"assigned_size_gte,omitempty"`
+	AssignedSizeGte *int64 `json:"assigned_size_gte,omitempty"`
 
 	// assigned size in
-	AssignedSizeIn []float64 `json:"assigned_size_in,omitempty"`
+	AssignedSizeIn []int64 `json:"assigned_size_in,omitempty"`
 
 	// assigned size lt
-	AssignedSizeLt *float64 `json:"assigned_size_lt,omitempty"`
+	AssignedSizeLt *int64 `json:"assigned_size_lt,omitempty"`
 
 	// assigned size lte
-	AssignedSizeLte *float64 `json:"assigned_size_lte,omitempty"`
+	AssignedSizeLte *int64 `json:"assigned_size_lte,omitempty"`
 
 	// assigned size not
-	AssignedSizeNot *float64 `json:"assigned_size_not,omitempty"`
+	AssignedSizeNot *int64 `json:"assigned_size_not,omitempty"`
 
 	// assigned size not in
-	AssignedSizeNotIn []float64 `json:"assigned_size_not_in,omitempty"`
+	AssignedSizeNotIn []int64 `json:"assigned_size_not_in,omitempty"`
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps gt
-	BpsGt *float64 `json:"bps_gt,omitempty"`
+	BpsGt *int64 `json:"bps_gt,omitempty"`
 
 	// bps gte
-	BpsGte *float64 `json:"bps_gte,omitempty"`
+	BpsGte *int64 `json:"bps_gte,omitempty"`
 
 	// bps in
-	BpsIn []float64 `json:"bps_in,omitempty"`
+	BpsIn []int64 `json:"bps_in,omitempty"`
 
 	// bps lt
-	BpsLt *float64 `json:"bps_lt,omitempty"`
+	BpsLt *int64 `json:"bps_lt,omitempty"`
 
 	// bps lte
-	BpsLte *float64 `json:"bps_lte,omitempty"`
+	BpsLte *int64 `json:"bps_lte,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max gt
-	BpsMaxGt *float64 `json:"bps_max_gt,omitempty"`
+	BpsMaxGt *int64 `json:"bps_max_gt,omitempty"`
 
 	// bps max gte
-	BpsMaxGte *float64 `json:"bps_max_gte,omitempty"`
+	BpsMaxGte *int64 `json:"bps_max_gte,omitempty"`
 
 	// bps max in
-	BpsMaxIn []float64 `json:"bps_max_in,omitempty"`
+	BpsMaxIn []int64 `json:"bps_max_in,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps max length gt
-	BpsMaxLengthGt *float64 `json:"bps_max_length_gt,omitempty"`
+	BpsMaxLengthGt *int64 `json:"bps_max_length_gt,omitempty"`
 
 	// bps max length gte
-	BpsMaxLengthGte *float64 `json:"bps_max_length_gte,omitempty"`
+	BpsMaxLengthGte *int64 `json:"bps_max_length_gte,omitempty"`
 
 	// bps max length in
-	BpsMaxLengthIn []float64 `json:"bps_max_length_in,omitempty"`
+	BpsMaxLengthIn []int64 `json:"bps_max_length_in,omitempty"`
 
 	// bps max length lt
-	BpsMaxLengthLt *float64 `json:"bps_max_length_lt,omitempty"`
+	BpsMaxLengthLt *int64 `json:"bps_max_length_lt,omitempty"`
 
 	// bps max length lte
-	BpsMaxLengthLte *float64 `json:"bps_max_length_lte,omitempty"`
+	BpsMaxLengthLte *int64 `json:"bps_max_length_lte,omitempty"`
 
 	// bps max length not
-	BpsMaxLengthNot *float64 `json:"bps_max_length_not,omitempty"`
+	BpsMaxLengthNot *int64 `json:"bps_max_length_not,omitempty"`
 
 	// bps max length not in
-	BpsMaxLengthNotIn []float64 `json:"bps_max_length_not_in,omitempty"`
+	BpsMaxLengthNotIn []int64 `json:"bps_max_length_not_in,omitempty"`
 
 	// bps max lt
-	BpsMaxLt *float64 `json:"bps_max_lt,omitempty"`
+	BpsMaxLt *int64 `json:"bps_max_lt,omitempty"`
 
 	// bps max lte
-	BpsMaxLte *float64 `json:"bps_max_lte,omitempty"`
+	BpsMaxLte *int64 `json:"bps_max_lte,omitempty"`
 
 	// bps max not
-	BpsMaxNot *float64 `json:"bps_max_not,omitempty"`
+	BpsMaxNot *int64 `json:"bps_max_not,omitempty"`
 
 	// bps max not in
-	BpsMaxNotIn []float64 `json:"bps_max_not_in,omitempty"`
+	BpsMaxNotIn []int64 `json:"bps_max_not_in,omitempty"`
 
 	// bps not
-	BpsNot *float64 `json:"bps_not,omitempty"`
+	BpsNot *int64 `json:"bps_not,omitempty"`
 
 	// bps not in
-	BpsNotIn []float64 `json:"bps_not_in,omitempty"`
+	BpsNotIn []int64 `json:"bps_not_in,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd gt
-	BpsRdGt *float64 `json:"bps_rd_gt,omitempty"`
+	BpsRdGt *int64 `json:"bps_rd_gt,omitempty"`
 
 	// bps rd gte
-	BpsRdGte *float64 `json:"bps_rd_gte,omitempty"`
+	BpsRdGte *int64 `json:"bps_rd_gte,omitempty"`
 
 	// bps rd in
-	BpsRdIn []float64 `json:"bps_rd_in,omitempty"`
+	BpsRdIn []int64 `json:"bps_rd_in,omitempty"`
 
 	// bps rd lt
-	BpsRdLt *float64 `json:"bps_rd_lt,omitempty"`
+	BpsRdLt *int64 `json:"bps_rd_lt,omitempty"`
 
 	// bps rd lte
-	BpsRdLte *float64 `json:"bps_rd_lte,omitempty"`
+	BpsRdLte *int64 `json:"bps_rd_lte,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max gt
-	BpsRdMaxGt *float64 `json:"bps_rd_max_gt,omitempty"`
+	BpsRdMaxGt *int64 `json:"bps_rd_max_gt,omitempty"`
 
 	// bps rd max gte
-	BpsRdMaxGte *float64 `json:"bps_rd_max_gte,omitempty"`
+	BpsRdMaxGte *int64 `json:"bps_rd_max_gte,omitempty"`
 
 	// bps rd max in
-	BpsRdMaxIn []float64 `json:"bps_rd_max_in,omitempty"`
+	BpsRdMaxIn []int64 `json:"bps_rd_max_in,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps rd max length gt
-	BpsRdMaxLengthGt *float64 `json:"bps_rd_max_length_gt,omitempty"`
+	BpsRdMaxLengthGt *int64 `json:"bps_rd_max_length_gt,omitempty"`
 
 	// bps rd max length gte
-	BpsRdMaxLengthGte *float64 `json:"bps_rd_max_length_gte,omitempty"`
+	BpsRdMaxLengthGte *int64 `json:"bps_rd_max_length_gte,omitempty"`
 
 	// bps rd max length in
-	BpsRdMaxLengthIn []float64 `json:"bps_rd_max_length_in,omitempty"`
+	BpsRdMaxLengthIn []int64 `json:"bps_rd_max_length_in,omitempty"`
 
 	// bps rd max length lt
-	BpsRdMaxLengthLt *float64 `json:"bps_rd_max_length_lt,omitempty"`
+	BpsRdMaxLengthLt *int64 `json:"bps_rd_max_length_lt,omitempty"`
 
 	// bps rd max length lte
-	BpsRdMaxLengthLte *float64 `json:"bps_rd_max_length_lte,omitempty"`
+	BpsRdMaxLengthLte *int64 `json:"bps_rd_max_length_lte,omitempty"`
 
 	// bps rd max length not
-	BpsRdMaxLengthNot *float64 `json:"bps_rd_max_length_not,omitempty"`
+	BpsRdMaxLengthNot *int64 `json:"bps_rd_max_length_not,omitempty"`
 
 	// bps rd max length not in
-	BpsRdMaxLengthNotIn []float64 `json:"bps_rd_max_length_not_in,omitempty"`
+	BpsRdMaxLengthNotIn []int64 `json:"bps_rd_max_length_not_in,omitempty"`
 
 	// bps rd max lt
-	BpsRdMaxLt *float64 `json:"bps_rd_max_lt,omitempty"`
+	BpsRdMaxLt *int64 `json:"bps_rd_max_lt,omitempty"`
 
 	// bps rd max lte
-	BpsRdMaxLte *float64 `json:"bps_rd_max_lte,omitempty"`
+	BpsRdMaxLte *int64 `json:"bps_rd_max_lte,omitempty"`
 
 	// bps rd max not
-	BpsRdMaxNot *float64 `json:"bps_rd_max_not,omitempty"`
+	BpsRdMaxNot *int64 `json:"bps_rd_max_not,omitempty"`
 
 	// bps rd max not in
-	BpsRdMaxNotIn []float64 `json:"bps_rd_max_not_in,omitempty"`
+	BpsRdMaxNotIn []int64 `json:"bps_rd_max_not_in,omitempty"`
 
 	// bps rd not
-	BpsRdNot *float64 `json:"bps_rd_not,omitempty"`
+	BpsRdNot *int64 `json:"bps_rd_not,omitempty"`
 
 	// bps rd not in
-	BpsRdNotIn []float64 `json:"bps_rd_not_in,omitempty"`
+	BpsRdNotIn []int64 `json:"bps_rd_not_in,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr gt
-	BpsWrGt *float64 `json:"bps_wr_gt,omitempty"`
+	BpsWrGt *int64 `json:"bps_wr_gt,omitempty"`
 
 	// bps wr gte
-	BpsWrGte *float64 `json:"bps_wr_gte,omitempty"`
+	BpsWrGte *int64 `json:"bps_wr_gte,omitempty"`
 
 	// bps wr in
-	BpsWrIn []float64 `json:"bps_wr_in,omitempty"`
+	BpsWrIn []int64 `json:"bps_wr_in,omitempty"`
 
 	// bps wr lt
-	BpsWrLt *float64 `json:"bps_wr_lt,omitempty"`
+	BpsWrLt *int64 `json:"bps_wr_lt,omitempty"`
 
 	// bps wr lte
-	BpsWrLte *float64 `json:"bps_wr_lte,omitempty"`
+	BpsWrLte *int64 `json:"bps_wr_lte,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max gt
-	BpsWrMaxGt *float64 `json:"bps_wr_max_gt,omitempty"`
+	BpsWrMaxGt *int64 `json:"bps_wr_max_gt,omitempty"`
 
 	// bps wr max gte
-	BpsWrMaxGte *float64 `json:"bps_wr_max_gte,omitempty"`
+	BpsWrMaxGte *int64 `json:"bps_wr_max_gte,omitempty"`
 
 	// bps wr max in
-	BpsWrMaxIn []float64 `json:"bps_wr_max_in,omitempty"`
+	BpsWrMaxIn []int64 `json:"bps_wr_max_in,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// bps wr max length gt
-	BpsWrMaxLengthGt *float64 `json:"bps_wr_max_length_gt,omitempty"`
+	BpsWrMaxLengthGt *int64 `json:"bps_wr_max_length_gt,omitempty"`
 
 	// bps wr max length gte
-	BpsWrMaxLengthGte *float64 `json:"bps_wr_max_length_gte,omitempty"`
+	BpsWrMaxLengthGte *int64 `json:"bps_wr_max_length_gte,omitempty"`
 
 	// bps wr max length in
-	BpsWrMaxLengthIn []float64 `json:"bps_wr_max_length_in,omitempty"`
+	BpsWrMaxLengthIn []int64 `json:"bps_wr_max_length_in,omitempty"`
 
 	// bps wr max length lt
-	BpsWrMaxLengthLt *float64 `json:"bps_wr_max_length_lt,omitempty"`
+	BpsWrMaxLengthLt *int64 `json:"bps_wr_max_length_lt,omitempty"`
 
 	// bps wr max length lte
-	BpsWrMaxLengthLte *float64 `json:"bps_wr_max_length_lte,omitempty"`
+	BpsWrMaxLengthLte *int64 `json:"bps_wr_max_length_lte,omitempty"`
 
 	// bps wr max length not
-	BpsWrMaxLengthNot *float64 `json:"bps_wr_max_length_not,omitempty"`
+	BpsWrMaxLengthNot *int64 `json:"bps_wr_max_length_not,omitempty"`
 
 	// bps wr max length not in
-	BpsWrMaxLengthNotIn []float64 `json:"bps_wr_max_length_not_in,omitempty"`
+	BpsWrMaxLengthNotIn []int64 `json:"bps_wr_max_length_not_in,omitempty"`
 
 	// bps wr max lt
-	BpsWrMaxLt *float64 `json:"bps_wr_max_lt,omitempty"`
+	BpsWrMaxLt *int64 `json:"bps_wr_max_lt,omitempty"`
 
 	// bps wr max lte
-	BpsWrMaxLte *float64 `json:"bps_wr_max_lte,omitempty"`
+	BpsWrMaxLte *int64 `json:"bps_wr_max_lte,omitempty"`
 
 	// bps wr max not
-	BpsWrMaxNot *float64 `json:"bps_wr_max_not,omitempty"`
+	BpsWrMaxNot *int64 `json:"bps_wr_max_not,omitempty"`
 
 	// bps wr max not in
-	BpsWrMaxNotIn []float64 `json:"bps_wr_max_not_in,omitempty"`
+	BpsWrMaxNotIn []int64 `json:"bps_wr_max_not_in,omitempty"`
 
 	// bps wr not
-	BpsWrNot *float64 `json:"bps_wr_not,omitempty"`
+	BpsWrNot *int64 `json:"bps_wr_not,omitempty"`
 
 	// bps wr not in
-	BpsWrNotIn []float64 `json:"bps_wr_not_in,omitempty"`
+	BpsWrNotIn []int64 `json:"bps_wr_not_in,omitempty"`
 
 	// consistency group
 	ConsistencyGroup *ConsistencyGroupWhereInput `json:"consistency_group,omitempty"`
@@ -369,244 +369,244 @@ type IscsiLunWhereInput struct {
 	IDStartsWith *string `json:"id_starts_with,omitempty"`
 
 	// io size
-	IoSize *float64 `json:"io_size,omitempty"`
+	IoSize *int64 `json:"io_size,omitempty"`
 
 	// io size gt
-	IoSizeGt *float64 `json:"io_size_gt,omitempty"`
+	IoSizeGt *int64 `json:"io_size_gt,omitempty"`
 
 	// io size gte
-	IoSizeGte *float64 `json:"io_size_gte,omitempty"`
+	IoSizeGte *int64 `json:"io_size_gte,omitempty"`
 
 	// io size in
-	IoSizeIn []float64 `json:"io_size_in,omitempty"`
+	IoSizeIn []int64 `json:"io_size_in,omitempty"`
 
 	// io size lt
-	IoSizeLt *float64 `json:"io_size_lt,omitempty"`
+	IoSizeLt *int64 `json:"io_size_lt,omitempty"`
 
 	// io size lte
-	IoSizeLte *float64 `json:"io_size_lte,omitempty"`
+	IoSizeLte *int64 `json:"io_size_lte,omitempty"`
 
 	// io size not
-	IoSizeNot *float64 `json:"io_size_not,omitempty"`
+	IoSizeNot *int64 `json:"io_size_not,omitempty"`
 
 	// io size not in
-	IoSizeNotIn []float64 `json:"io_size_not_in,omitempty"`
+	IoSizeNotIn []int64 `json:"io_size_not_in,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops gt
-	IopsGt *float64 `json:"iops_gt,omitempty"`
+	IopsGt *int64 `json:"iops_gt,omitempty"`
 
 	// iops gte
-	IopsGte *float64 `json:"iops_gte,omitempty"`
+	IopsGte *int64 `json:"iops_gte,omitempty"`
 
 	// iops in
-	IopsIn []float64 `json:"iops_in,omitempty"`
+	IopsIn []int64 `json:"iops_in,omitempty"`
 
 	// iops lt
-	IopsLt *float64 `json:"iops_lt,omitempty"`
+	IopsLt *int64 `json:"iops_lt,omitempty"`
 
 	// iops lte
-	IopsLte *float64 `json:"iops_lte,omitempty"`
+	IopsLte *int64 `json:"iops_lte,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max gt
-	IopsMaxGt *float64 `json:"iops_max_gt,omitempty"`
+	IopsMaxGt *int64 `json:"iops_max_gt,omitempty"`
 
 	// iops max gte
-	IopsMaxGte *float64 `json:"iops_max_gte,omitempty"`
+	IopsMaxGte *int64 `json:"iops_max_gte,omitempty"`
 
 	// iops max in
-	IopsMaxIn []float64 `json:"iops_max_in,omitempty"`
+	IopsMaxIn []int64 `json:"iops_max_in,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops max length gt
-	IopsMaxLengthGt *float64 `json:"iops_max_length_gt,omitempty"`
+	IopsMaxLengthGt *int64 `json:"iops_max_length_gt,omitempty"`
 
 	// iops max length gte
-	IopsMaxLengthGte *float64 `json:"iops_max_length_gte,omitempty"`
+	IopsMaxLengthGte *int64 `json:"iops_max_length_gte,omitempty"`
 
 	// iops max length in
-	IopsMaxLengthIn []float64 `json:"iops_max_length_in,omitempty"`
+	IopsMaxLengthIn []int64 `json:"iops_max_length_in,omitempty"`
 
 	// iops max length lt
-	IopsMaxLengthLt *float64 `json:"iops_max_length_lt,omitempty"`
+	IopsMaxLengthLt *int64 `json:"iops_max_length_lt,omitempty"`
 
 	// iops max length lte
-	IopsMaxLengthLte *float64 `json:"iops_max_length_lte,omitempty"`
+	IopsMaxLengthLte *int64 `json:"iops_max_length_lte,omitempty"`
 
 	// iops max length not
-	IopsMaxLengthNot *float64 `json:"iops_max_length_not,omitempty"`
+	IopsMaxLengthNot *int64 `json:"iops_max_length_not,omitempty"`
 
 	// iops max length not in
-	IopsMaxLengthNotIn []float64 `json:"iops_max_length_not_in,omitempty"`
+	IopsMaxLengthNotIn []int64 `json:"iops_max_length_not_in,omitempty"`
 
 	// iops max lt
-	IopsMaxLt *float64 `json:"iops_max_lt,omitempty"`
+	IopsMaxLt *int64 `json:"iops_max_lt,omitempty"`
 
 	// iops max lte
-	IopsMaxLte *float64 `json:"iops_max_lte,omitempty"`
+	IopsMaxLte *int64 `json:"iops_max_lte,omitempty"`
 
 	// iops max not
-	IopsMaxNot *float64 `json:"iops_max_not,omitempty"`
+	IopsMaxNot *int64 `json:"iops_max_not,omitempty"`
 
 	// iops max not in
-	IopsMaxNotIn []float64 `json:"iops_max_not_in,omitempty"`
+	IopsMaxNotIn []int64 `json:"iops_max_not_in,omitempty"`
 
 	// iops not
-	IopsNot *float64 `json:"iops_not,omitempty"`
+	IopsNot *int64 `json:"iops_not,omitempty"`
 
 	// iops not in
-	IopsNotIn []float64 `json:"iops_not_in,omitempty"`
+	IopsNotIn []int64 `json:"iops_not_in,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd gt
-	IopsRdGt *float64 `json:"iops_rd_gt,omitempty"`
+	IopsRdGt *int64 `json:"iops_rd_gt,omitempty"`
 
 	// iops rd gte
-	IopsRdGte *float64 `json:"iops_rd_gte,omitempty"`
+	IopsRdGte *int64 `json:"iops_rd_gte,omitempty"`
 
 	// iops rd in
-	IopsRdIn []float64 `json:"iops_rd_in,omitempty"`
+	IopsRdIn []int64 `json:"iops_rd_in,omitempty"`
 
 	// iops rd lt
-	IopsRdLt *float64 `json:"iops_rd_lt,omitempty"`
+	IopsRdLt *int64 `json:"iops_rd_lt,omitempty"`
 
 	// iops rd lte
-	IopsRdLte *float64 `json:"iops_rd_lte,omitempty"`
+	IopsRdLte *int64 `json:"iops_rd_lte,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max gt
-	IopsRdMaxGt *float64 `json:"iops_rd_max_gt,omitempty"`
+	IopsRdMaxGt *int64 `json:"iops_rd_max_gt,omitempty"`
 
 	// iops rd max gte
-	IopsRdMaxGte *float64 `json:"iops_rd_max_gte,omitempty"`
+	IopsRdMaxGte *int64 `json:"iops_rd_max_gte,omitempty"`
 
 	// iops rd max in
-	IopsRdMaxIn []float64 `json:"iops_rd_max_in,omitempty"`
+	IopsRdMaxIn []int64 `json:"iops_rd_max_in,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops rd max length gt
-	IopsRdMaxLengthGt *float64 `json:"iops_rd_max_length_gt,omitempty"`
+	IopsRdMaxLengthGt *int64 `json:"iops_rd_max_length_gt,omitempty"`
 
 	// iops rd max length gte
-	IopsRdMaxLengthGte *float64 `json:"iops_rd_max_length_gte,omitempty"`
+	IopsRdMaxLengthGte *int64 `json:"iops_rd_max_length_gte,omitempty"`
 
 	// iops rd max length in
-	IopsRdMaxLengthIn []float64 `json:"iops_rd_max_length_in,omitempty"`
+	IopsRdMaxLengthIn []int64 `json:"iops_rd_max_length_in,omitempty"`
 
 	// iops rd max length lt
-	IopsRdMaxLengthLt *float64 `json:"iops_rd_max_length_lt,omitempty"`
+	IopsRdMaxLengthLt *int64 `json:"iops_rd_max_length_lt,omitempty"`
 
 	// iops rd max length lte
-	IopsRdMaxLengthLte *float64 `json:"iops_rd_max_length_lte,omitempty"`
+	IopsRdMaxLengthLte *int64 `json:"iops_rd_max_length_lte,omitempty"`
 
 	// iops rd max length not
-	IopsRdMaxLengthNot *float64 `json:"iops_rd_max_length_not,omitempty"`
+	IopsRdMaxLengthNot *int64 `json:"iops_rd_max_length_not,omitempty"`
 
 	// iops rd max length not in
-	IopsRdMaxLengthNotIn []float64 `json:"iops_rd_max_length_not_in,omitempty"`
+	IopsRdMaxLengthNotIn []int64 `json:"iops_rd_max_length_not_in,omitempty"`
 
 	// iops rd max lt
-	IopsRdMaxLt *float64 `json:"iops_rd_max_lt,omitempty"`
+	IopsRdMaxLt *int64 `json:"iops_rd_max_lt,omitempty"`
 
 	// iops rd max lte
-	IopsRdMaxLte *float64 `json:"iops_rd_max_lte,omitempty"`
+	IopsRdMaxLte *int64 `json:"iops_rd_max_lte,omitempty"`
 
 	// iops rd max not
-	IopsRdMaxNot *float64 `json:"iops_rd_max_not,omitempty"`
+	IopsRdMaxNot *int64 `json:"iops_rd_max_not,omitempty"`
 
 	// iops rd max not in
-	IopsRdMaxNotIn []float64 `json:"iops_rd_max_not_in,omitempty"`
+	IopsRdMaxNotIn []int64 `json:"iops_rd_max_not_in,omitempty"`
 
 	// iops rd not
-	IopsRdNot *float64 `json:"iops_rd_not,omitempty"`
+	IopsRdNot *int64 `json:"iops_rd_not,omitempty"`
 
 	// iops rd not in
-	IopsRdNotIn []float64 `json:"iops_rd_not_in,omitempty"`
+	IopsRdNotIn []int64 `json:"iops_rd_not_in,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr gt
-	IopsWrGt *float64 `json:"iops_wr_gt,omitempty"`
+	IopsWrGt *int64 `json:"iops_wr_gt,omitempty"`
 
 	// iops wr gte
-	IopsWrGte *float64 `json:"iops_wr_gte,omitempty"`
+	IopsWrGte *int64 `json:"iops_wr_gte,omitempty"`
 
 	// iops wr in
-	IopsWrIn []float64 `json:"iops_wr_in,omitempty"`
+	IopsWrIn []int64 `json:"iops_wr_in,omitempty"`
 
 	// iops wr lt
-	IopsWrLt *float64 `json:"iops_wr_lt,omitempty"`
+	IopsWrLt *int64 `json:"iops_wr_lt,omitempty"`
 
 	// iops wr lte
-	IopsWrLte *float64 `json:"iops_wr_lte,omitempty"`
+	IopsWrLte *int64 `json:"iops_wr_lte,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max gt
-	IopsWrMaxGt *float64 `json:"iops_wr_max_gt,omitempty"`
+	IopsWrMaxGt *int64 `json:"iops_wr_max_gt,omitempty"`
 
 	// iops wr max gte
-	IopsWrMaxGte *float64 `json:"iops_wr_max_gte,omitempty"`
+	IopsWrMaxGte *int64 `json:"iops_wr_max_gte,omitempty"`
 
 	// iops wr max in
-	IopsWrMaxIn []float64 `json:"iops_wr_max_in,omitempty"`
+	IopsWrMaxIn []int64 `json:"iops_wr_max_in,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// iops wr max length gt
-	IopsWrMaxLengthGt *float64 `json:"iops_wr_max_length_gt,omitempty"`
+	IopsWrMaxLengthGt *int64 `json:"iops_wr_max_length_gt,omitempty"`
 
 	// iops wr max length gte
-	IopsWrMaxLengthGte *float64 `json:"iops_wr_max_length_gte,omitempty"`
+	IopsWrMaxLengthGte *int64 `json:"iops_wr_max_length_gte,omitempty"`
 
 	// iops wr max length in
-	IopsWrMaxLengthIn []float64 `json:"iops_wr_max_length_in,omitempty"`
+	IopsWrMaxLengthIn []int64 `json:"iops_wr_max_length_in,omitempty"`
 
 	// iops wr max length lt
-	IopsWrMaxLengthLt *float64 `json:"iops_wr_max_length_lt,omitempty"`
+	IopsWrMaxLengthLt *int64 `json:"iops_wr_max_length_lt,omitempty"`
 
 	// iops wr max length lte
-	IopsWrMaxLengthLte *float64 `json:"iops_wr_max_length_lte,omitempty"`
+	IopsWrMaxLengthLte *int64 `json:"iops_wr_max_length_lte,omitempty"`
 
 	// iops wr max length not
-	IopsWrMaxLengthNot *float64 `json:"iops_wr_max_length_not,omitempty"`
+	IopsWrMaxLengthNot *int64 `json:"iops_wr_max_length_not,omitempty"`
 
 	// iops wr max length not in
-	IopsWrMaxLengthNotIn []float64 `json:"iops_wr_max_length_not_in,omitempty"`
+	IopsWrMaxLengthNotIn []int64 `json:"iops_wr_max_length_not_in,omitempty"`
 
 	// iops wr max lt
-	IopsWrMaxLt *float64 `json:"iops_wr_max_lt,omitempty"`
+	IopsWrMaxLt *int64 `json:"iops_wr_max_lt,omitempty"`
 
 	// iops wr max lte
-	IopsWrMaxLte *float64 `json:"iops_wr_max_lte,omitempty"`
+	IopsWrMaxLte *int64 `json:"iops_wr_max_lte,omitempty"`
 
 	// iops wr max not
-	IopsWrMaxNot *float64 `json:"iops_wr_max_not,omitempty"`
+	IopsWrMaxNot *int64 `json:"iops_wr_max_not,omitempty"`
 
 	// iops wr max not in
-	IopsWrMaxNotIn []float64 `json:"iops_wr_max_not_in,omitempty"`
+	IopsWrMaxNotIn []int64 `json:"iops_wr_max_not_in,omitempty"`
 
 	// iops wr not
-	IopsWrNot *float64 `json:"iops_wr_not,omitempty"`
+	IopsWrNot *int64 `json:"iops_wr_not,omitempty"`
 
 	// iops wr not in
-	IopsWrNotIn []float64 `json:"iops_wr_not_in,omitempty"`
+	IopsWrNotIn []int64 `json:"iops_wr_not_in,omitempty"`
 
 	// iscsi target
 	IscsiTarget *IscsiTargetWhereInput `json:"iscsi_target,omitempty"`
@@ -777,28 +777,28 @@ type IscsiLunWhereInput struct {
 	ReplicaNumNotIn []int32 `json:"replica_num_not_in,omitempty"`
 
 	// shared size
-	SharedSize *float64 `json:"shared_size,omitempty"`
+	SharedSize *int64 `json:"shared_size,omitempty"`
 
 	// shared size gt
-	SharedSizeGt *float64 `json:"shared_size_gt,omitempty"`
+	SharedSizeGt *int64 `json:"shared_size_gt,omitempty"`
 
 	// shared size gte
-	SharedSizeGte *float64 `json:"shared_size_gte,omitempty"`
+	SharedSizeGte *int64 `json:"shared_size_gte,omitempty"`
 
 	// shared size in
-	SharedSizeIn []float64 `json:"shared_size_in,omitempty"`
+	SharedSizeIn []int64 `json:"shared_size_in,omitempty"`
 
 	// shared size lt
-	SharedSizeLt *float64 `json:"shared_size_lt,omitempty"`
+	SharedSizeLt *int64 `json:"shared_size_lt,omitempty"`
 
 	// shared size lte
-	SharedSizeLte *float64 `json:"shared_size_lte,omitempty"`
+	SharedSizeLte *int64 `json:"shared_size_lte,omitempty"`
 
 	// shared size not
-	SharedSizeNot *float64 `json:"shared_size_not,omitempty"`
+	SharedSizeNot *int64 `json:"shared_size_not,omitempty"`
 
 	// shared size not in
-	SharedSizeNotIn []float64 `json:"shared_size_not_in,omitempty"`
+	SharedSizeNotIn []int64 `json:"shared_size_not_in,omitempty"`
 
 	// snapshot num
 	SnapshotNum *int32 `json:"snapshot_num,omitempty"`
@@ -849,28 +849,28 @@ type IscsiLunWhereInput struct {
 	StripeNumNotIn []int32 `json:"stripe_num_not_in,omitempty"`
 
 	// stripe size
-	StripeSize *float64 `json:"stripe_size,omitempty"`
+	StripeSize *int64 `json:"stripe_size,omitempty"`
 
 	// stripe size gt
-	StripeSizeGt *float64 `json:"stripe_size_gt,omitempty"`
+	StripeSizeGt *int64 `json:"stripe_size_gt,omitempty"`
 
 	// stripe size gte
-	StripeSizeGte *float64 `json:"stripe_size_gte,omitempty"`
+	StripeSizeGte *int64 `json:"stripe_size_gte,omitempty"`
 
 	// stripe size in
-	StripeSizeIn []float64 `json:"stripe_size_in,omitempty"`
+	StripeSizeIn []int64 `json:"stripe_size_in,omitempty"`
 
 	// stripe size lt
-	StripeSizeLt *float64 `json:"stripe_size_lt,omitempty"`
+	StripeSizeLt *int64 `json:"stripe_size_lt,omitempty"`
 
 	// stripe size lte
-	StripeSizeLte *float64 `json:"stripe_size_lte,omitempty"`
+	StripeSizeLte *int64 `json:"stripe_size_lte,omitempty"`
 
 	// stripe size not
-	StripeSizeNot *float64 `json:"stripe_size_not,omitempty"`
+	StripeSizeNot *int64 `json:"stripe_size_not,omitempty"`
 
 	// stripe size not in
-	StripeSizeNotIn []float64 `json:"stripe_size_not_in,omitempty"`
+	StripeSizeNotIn []int64 `json:"stripe_size_not_in,omitempty"`
 
 	// thin provision
 	ThinProvision *bool `json:"thin_provision,omitempty"`
@@ -879,28 +879,28 @@ type IscsiLunWhereInput struct {
 	ThinProvisionNot *bool `json:"thin_provision_not,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 
 	// zbs volume id
 	ZbsVolumeID *string `json:"zbs_volume_id,omitempty"`

--- a/models/iscsi_target.go
+++ b/models/iscsi_target.go
@@ -21,31 +21,31 @@ import (
 type IscsiTarget struct {
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// chap enabled
 	// Required: true
@@ -84,34 +84,34 @@ type IscsiTarget struct {
 	Internal *bool `json:"internal"`
 
 	// io size
-	IoSize *float64 `json:"io_size,omitempty"`
+	IoSize *int64 `json:"io_size,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// ip whitelist
 	// Required: true
@@ -149,7 +149,7 @@ type IscsiTarget struct {
 
 	// stripe size
 	// Required: true
-	StripeSize *float64 `json:"stripe_size"`
+	StripeSize *int64 `json:"stripe_size"`
 
 	// thin provision
 	// Required: true

--- a/models/iscsi_target_common_params.go
+++ b/models/iscsi_target_common_params.go
@@ -21,31 +21,31 @@ import (
 type IscsiTargetCommonParams struct {
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// chap enabled
 	ChapEnabled *bool `json:"chap_enabled,omitempty"`
@@ -63,31 +63,31 @@ type IscsiTargetCommonParams struct {
 	InitiatorChaps []*IscsiTargetCommonParamsInitiatorChapsItems0 `json:"initiator_chaps,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// ip whitelist
 	IPWhitelist *string `json:"ip_whitelist,omitempty"`

--- a/models/iscsi_target_creation_params.go
+++ b/models/iscsi_target_creation_params.go
@@ -37,7 +37,7 @@ type IscsiTargetCreationParams struct {
 
 	// stripe size
 	// Required: true
-	StripeSize *float64 `json:"stripe_size"`
+	StripeSize *int64 `json:"stripe_size"`
 
 	// thin provision
 	// Required: true
@@ -58,7 +58,7 @@ func (m *IscsiTargetCreationParams) UnmarshalJSON(raw []byte) error {
 
 		StripeNum *int32 `json:"stripe_num"`
 
-		StripeSize *float64 `json:"stripe_size"`
+		StripeSize *int64 `json:"stripe_size"`
 
 		ThinProvision *bool `json:"thin_provision"`
 	}
@@ -101,7 +101,7 @@ func (m IscsiTargetCreationParams) MarshalJSON() ([]byte, error) {
 
 		StripeNum *int32 `json:"stripe_num"`
 
-		StripeSize *float64 `json:"stripe_size"`
+		StripeSize *int64 `json:"stripe_size"`
 
 		ThinProvision *bool `json:"thin_provision"`
 	}

--- a/models/iscsi_target_where_input.go
+++ b/models/iscsi_target_where_input.go
@@ -30,220 +30,220 @@ type IscsiTargetWhereInput struct {
 	OR []*IscsiTargetWhereInput `json:"OR,omitempty"`
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps gt
-	BpsGt *float64 `json:"bps_gt,omitempty"`
+	BpsGt *int64 `json:"bps_gt,omitempty"`
 
 	// bps gte
-	BpsGte *float64 `json:"bps_gte,omitempty"`
+	BpsGte *int64 `json:"bps_gte,omitempty"`
 
 	// bps in
-	BpsIn []float64 `json:"bps_in,omitempty"`
+	BpsIn []int64 `json:"bps_in,omitempty"`
 
 	// bps lt
-	BpsLt *float64 `json:"bps_lt,omitempty"`
+	BpsLt *int64 `json:"bps_lt,omitempty"`
 
 	// bps lte
-	BpsLte *float64 `json:"bps_lte,omitempty"`
+	BpsLte *int64 `json:"bps_lte,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max gt
-	BpsMaxGt *float64 `json:"bps_max_gt,omitempty"`
+	BpsMaxGt *int64 `json:"bps_max_gt,omitempty"`
 
 	// bps max gte
-	BpsMaxGte *float64 `json:"bps_max_gte,omitempty"`
+	BpsMaxGte *int64 `json:"bps_max_gte,omitempty"`
 
 	// bps max in
-	BpsMaxIn []float64 `json:"bps_max_in,omitempty"`
+	BpsMaxIn []int64 `json:"bps_max_in,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps max length gt
-	BpsMaxLengthGt *float64 `json:"bps_max_length_gt,omitempty"`
+	BpsMaxLengthGt *int64 `json:"bps_max_length_gt,omitempty"`
 
 	// bps max length gte
-	BpsMaxLengthGte *float64 `json:"bps_max_length_gte,omitempty"`
+	BpsMaxLengthGte *int64 `json:"bps_max_length_gte,omitempty"`
 
 	// bps max length in
-	BpsMaxLengthIn []float64 `json:"bps_max_length_in,omitempty"`
+	BpsMaxLengthIn []int64 `json:"bps_max_length_in,omitempty"`
 
 	// bps max length lt
-	BpsMaxLengthLt *float64 `json:"bps_max_length_lt,omitempty"`
+	BpsMaxLengthLt *int64 `json:"bps_max_length_lt,omitempty"`
 
 	// bps max length lte
-	BpsMaxLengthLte *float64 `json:"bps_max_length_lte,omitempty"`
+	BpsMaxLengthLte *int64 `json:"bps_max_length_lte,omitempty"`
 
 	// bps max length not
-	BpsMaxLengthNot *float64 `json:"bps_max_length_not,omitempty"`
+	BpsMaxLengthNot *int64 `json:"bps_max_length_not,omitempty"`
 
 	// bps max length not in
-	BpsMaxLengthNotIn []float64 `json:"bps_max_length_not_in,omitempty"`
+	BpsMaxLengthNotIn []int64 `json:"bps_max_length_not_in,omitempty"`
 
 	// bps max lt
-	BpsMaxLt *float64 `json:"bps_max_lt,omitempty"`
+	BpsMaxLt *int64 `json:"bps_max_lt,omitempty"`
 
 	// bps max lte
-	BpsMaxLte *float64 `json:"bps_max_lte,omitempty"`
+	BpsMaxLte *int64 `json:"bps_max_lte,omitempty"`
 
 	// bps max not
-	BpsMaxNot *float64 `json:"bps_max_not,omitempty"`
+	BpsMaxNot *int64 `json:"bps_max_not,omitempty"`
 
 	// bps max not in
-	BpsMaxNotIn []float64 `json:"bps_max_not_in,omitempty"`
+	BpsMaxNotIn []int64 `json:"bps_max_not_in,omitempty"`
 
 	// bps not
-	BpsNot *float64 `json:"bps_not,omitempty"`
+	BpsNot *int64 `json:"bps_not,omitempty"`
 
 	// bps not in
-	BpsNotIn []float64 `json:"bps_not_in,omitempty"`
+	BpsNotIn []int64 `json:"bps_not_in,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd gt
-	BpsRdGt *float64 `json:"bps_rd_gt,omitempty"`
+	BpsRdGt *int64 `json:"bps_rd_gt,omitempty"`
 
 	// bps rd gte
-	BpsRdGte *float64 `json:"bps_rd_gte,omitempty"`
+	BpsRdGte *int64 `json:"bps_rd_gte,omitempty"`
 
 	// bps rd in
-	BpsRdIn []float64 `json:"bps_rd_in,omitempty"`
+	BpsRdIn []int64 `json:"bps_rd_in,omitempty"`
 
 	// bps rd lt
-	BpsRdLt *float64 `json:"bps_rd_lt,omitempty"`
+	BpsRdLt *int64 `json:"bps_rd_lt,omitempty"`
 
 	// bps rd lte
-	BpsRdLte *float64 `json:"bps_rd_lte,omitempty"`
+	BpsRdLte *int64 `json:"bps_rd_lte,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max gt
-	BpsRdMaxGt *float64 `json:"bps_rd_max_gt,omitempty"`
+	BpsRdMaxGt *int64 `json:"bps_rd_max_gt,omitempty"`
 
 	// bps rd max gte
-	BpsRdMaxGte *float64 `json:"bps_rd_max_gte,omitempty"`
+	BpsRdMaxGte *int64 `json:"bps_rd_max_gte,omitempty"`
 
 	// bps rd max in
-	BpsRdMaxIn []float64 `json:"bps_rd_max_in,omitempty"`
+	BpsRdMaxIn []int64 `json:"bps_rd_max_in,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps rd max length gt
-	BpsRdMaxLengthGt *float64 `json:"bps_rd_max_length_gt,omitempty"`
+	BpsRdMaxLengthGt *int64 `json:"bps_rd_max_length_gt,omitempty"`
 
 	// bps rd max length gte
-	BpsRdMaxLengthGte *float64 `json:"bps_rd_max_length_gte,omitempty"`
+	BpsRdMaxLengthGte *int64 `json:"bps_rd_max_length_gte,omitempty"`
 
 	// bps rd max length in
-	BpsRdMaxLengthIn []float64 `json:"bps_rd_max_length_in,omitempty"`
+	BpsRdMaxLengthIn []int64 `json:"bps_rd_max_length_in,omitempty"`
 
 	// bps rd max length lt
-	BpsRdMaxLengthLt *float64 `json:"bps_rd_max_length_lt,omitempty"`
+	BpsRdMaxLengthLt *int64 `json:"bps_rd_max_length_lt,omitempty"`
 
 	// bps rd max length lte
-	BpsRdMaxLengthLte *float64 `json:"bps_rd_max_length_lte,omitempty"`
+	BpsRdMaxLengthLte *int64 `json:"bps_rd_max_length_lte,omitempty"`
 
 	// bps rd max length not
-	BpsRdMaxLengthNot *float64 `json:"bps_rd_max_length_not,omitempty"`
+	BpsRdMaxLengthNot *int64 `json:"bps_rd_max_length_not,omitempty"`
 
 	// bps rd max length not in
-	BpsRdMaxLengthNotIn []float64 `json:"bps_rd_max_length_not_in,omitempty"`
+	BpsRdMaxLengthNotIn []int64 `json:"bps_rd_max_length_not_in,omitempty"`
 
 	// bps rd max lt
-	BpsRdMaxLt *float64 `json:"bps_rd_max_lt,omitempty"`
+	BpsRdMaxLt *int64 `json:"bps_rd_max_lt,omitempty"`
 
 	// bps rd max lte
-	BpsRdMaxLte *float64 `json:"bps_rd_max_lte,omitempty"`
+	BpsRdMaxLte *int64 `json:"bps_rd_max_lte,omitempty"`
 
 	// bps rd max not
-	BpsRdMaxNot *float64 `json:"bps_rd_max_not,omitempty"`
+	BpsRdMaxNot *int64 `json:"bps_rd_max_not,omitempty"`
 
 	// bps rd max not in
-	BpsRdMaxNotIn []float64 `json:"bps_rd_max_not_in,omitempty"`
+	BpsRdMaxNotIn []int64 `json:"bps_rd_max_not_in,omitempty"`
 
 	// bps rd not
-	BpsRdNot *float64 `json:"bps_rd_not,omitempty"`
+	BpsRdNot *int64 `json:"bps_rd_not,omitempty"`
 
 	// bps rd not in
-	BpsRdNotIn []float64 `json:"bps_rd_not_in,omitempty"`
+	BpsRdNotIn []int64 `json:"bps_rd_not_in,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr gt
-	BpsWrGt *float64 `json:"bps_wr_gt,omitempty"`
+	BpsWrGt *int64 `json:"bps_wr_gt,omitempty"`
 
 	// bps wr gte
-	BpsWrGte *float64 `json:"bps_wr_gte,omitempty"`
+	BpsWrGte *int64 `json:"bps_wr_gte,omitempty"`
 
 	// bps wr in
-	BpsWrIn []float64 `json:"bps_wr_in,omitempty"`
+	BpsWrIn []int64 `json:"bps_wr_in,omitempty"`
 
 	// bps wr lt
-	BpsWrLt *float64 `json:"bps_wr_lt,omitempty"`
+	BpsWrLt *int64 `json:"bps_wr_lt,omitempty"`
 
 	// bps wr lte
-	BpsWrLte *float64 `json:"bps_wr_lte,omitempty"`
+	BpsWrLte *int64 `json:"bps_wr_lte,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max gt
-	BpsWrMaxGt *float64 `json:"bps_wr_max_gt,omitempty"`
+	BpsWrMaxGt *int64 `json:"bps_wr_max_gt,omitempty"`
 
 	// bps wr max gte
-	BpsWrMaxGte *float64 `json:"bps_wr_max_gte,omitempty"`
+	BpsWrMaxGte *int64 `json:"bps_wr_max_gte,omitempty"`
 
 	// bps wr max in
-	BpsWrMaxIn []float64 `json:"bps_wr_max_in,omitempty"`
+	BpsWrMaxIn []int64 `json:"bps_wr_max_in,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// bps wr max length gt
-	BpsWrMaxLengthGt *float64 `json:"bps_wr_max_length_gt,omitempty"`
+	BpsWrMaxLengthGt *int64 `json:"bps_wr_max_length_gt,omitempty"`
 
 	// bps wr max length gte
-	BpsWrMaxLengthGte *float64 `json:"bps_wr_max_length_gte,omitempty"`
+	BpsWrMaxLengthGte *int64 `json:"bps_wr_max_length_gte,omitempty"`
 
 	// bps wr max length in
-	BpsWrMaxLengthIn []float64 `json:"bps_wr_max_length_in,omitempty"`
+	BpsWrMaxLengthIn []int64 `json:"bps_wr_max_length_in,omitempty"`
 
 	// bps wr max length lt
-	BpsWrMaxLengthLt *float64 `json:"bps_wr_max_length_lt,omitempty"`
+	BpsWrMaxLengthLt *int64 `json:"bps_wr_max_length_lt,omitempty"`
 
 	// bps wr max length lte
-	BpsWrMaxLengthLte *float64 `json:"bps_wr_max_length_lte,omitempty"`
+	BpsWrMaxLengthLte *int64 `json:"bps_wr_max_length_lte,omitempty"`
 
 	// bps wr max length not
-	BpsWrMaxLengthNot *float64 `json:"bps_wr_max_length_not,omitempty"`
+	BpsWrMaxLengthNot *int64 `json:"bps_wr_max_length_not,omitempty"`
 
 	// bps wr max length not in
-	BpsWrMaxLengthNotIn []float64 `json:"bps_wr_max_length_not_in,omitempty"`
+	BpsWrMaxLengthNotIn []int64 `json:"bps_wr_max_length_not_in,omitempty"`
 
 	// bps wr max lt
-	BpsWrMaxLt *float64 `json:"bps_wr_max_lt,omitempty"`
+	BpsWrMaxLt *int64 `json:"bps_wr_max_lt,omitempty"`
 
 	// bps wr max lte
-	BpsWrMaxLte *float64 `json:"bps_wr_max_lte,omitempty"`
+	BpsWrMaxLte *int64 `json:"bps_wr_max_lte,omitempty"`
 
 	// bps wr max not
-	BpsWrMaxNot *float64 `json:"bps_wr_max_not,omitempty"`
+	BpsWrMaxNot *int64 `json:"bps_wr_max_not,omitempty"`
 
 	// bps wr max not in
-	BpsWrMaxNotIn []float64 `json:"bps_wr_max_not_in,omitempty"`
+	BpsWrMaxNotIn []int64 `json:"bps_wr_max_not_in,omitempty"`
 
 	// bps wr not
-	BpsWrNot *float64 `json:"bps_wr_not,omitempty"`
+	BpsWrNot *int64 `json:"bps_wr_not,omitempty"`
 
 	// bps wr not in
-	BpsWrNotIn []float64 `json:"bps_wr_not_in,omitempty"`
+	BpsWrNotIn []int64 `json:"bps_wr_not_in,omitempty"`
 
 	// chap enabled
 	ChapEnabled *bool `json:"chap_enabled,omitempty"`
@@ -447,244 +447,244 @@ type IscsiTargetWhereInput struct {
 	InternalNot *bool `json:"internal_not,omitempty"`
 
 	// io size
-	IoSize *float64 `json:"io_size,omitempty"`
+	IoSize *int64 `json:"io_size,omitempty"`
 
 	// io size gt
-	IoSizeGt *float64 `json:"io_size_gt,omitempty"`
+	IoSizeGt *int64 `json:"io_size_gt,omitempty"`
 
 	// io size gte
-	IoSizeGte *float64 `json:"io_size_gte,omitempty"`
+	IoSizeGte *int64 `json:"io_size_gte,omitempty"`
 
 	// io size in
-	IoSizeIn []float64 `json:"io_size_in,omitempty"`
+	IoSizeIn []int64 `json:"io_size_in,omitempty"`
 
 	// io size lt
-	IoSizeLt *float64 `json:"io_size_lt,omitempty"`
+	IoSizeLt *int64 `json:"io_size_lt,omitempty"`
 
 	// io size lte
-	IoSizeLte *float64 `json:"io_size_lte,omitempty"`
+	IoSizeLte *int64 `json:"io_size_lte,omitempty"`
 
 	// io size not
-	IoSizeNot *float64 `json:"io_size_not,omitempty"`
+	IoSizeNot *int64 `json:"io_size_not,omitempty"`
 
 	// io size not in
-	IoSizeNotIn []float64 `json:"io_size_not_in,omitempty"`
+	IoSizeNotIn []int64 `json:"io_size_not_in,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops gt
-	IopsGt *float64 `json:"iops_gt,omitempty"`
+	IopsGt *int64 `json:"iops_gt,omitempty"`
 
 	// iops gte
-	IopsGte *float64 `json:"iops_gte,omitempty"`
+	IopsGte *int64 `json:"iops_gte,omitempty"`
 
 	// iops in
-	IopsIn []float64 `json:"iops_in,omitempty"`
+	IopsIn []int64 `json:"iops_in,omitempty"`
 
 	// iops lt
-	IopsLt *float64 `json:"iops_lt,omitempty"`
+	IopsLt *int64 `json:"iops_lt,omitempty"`
 
 	// iops lte
-	IopsLte *float64 `json:"iops_lte,omitempty"`
+	IopsLte *int64 `json:"iops_lte,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max gt
-	IopsMaxGt *float64 `json:"iops_max_gt,omitempty"`
+	IopsMaxGt *int64 `json:"iops_max_gt,omitempty"`
 
 	// iops max gte
-	IopsMaxGte *float64 `json:"iops_max_gte,omitempty"`
+	IopsMaxGte *int64 `json:"iops_max_gte,omitempty"`
 
 	// iops max in
-	IopsMaxIn []float64 `json:"iops_max_in,omitempty"`
+	IopsMaxIn []int64 `json:"iops_max_in,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops max length gt
-	IopsMaxLengthGt *float64 `json:"iops_max_length_gt,omitempty"`
+	IopsMaxLengthGt *int64 `json:"iops_max_length_gt,omitempty"`
 
 	// iops max length gte
-	IopsMaxLengthGte *float64 `json:"iops_max_length_gte,omitempty"`
+	IopsMaxLengthGte *int64 `json:"iops_max_length_gte,omitempty"`
 
 	// iops max length in
-	IopsMaxLengthIn []float64 `json:"iops_max_length_in,omitempty"`
+	IopsMaxLengthIn []int64 `json:"iops_max_length_in,omitempty"`
 
 	// iops max length lt
-	IopsMaxLengthLt *float64 `json:"iops_max_length_lt,omitempty"`
+	IopsMaxLengthLt *int64 `json:"iops_max_length_lt,omitempty"`
 
 	// iops max length lte
-	IopsMaxLengthLte *float64 `json:"iops_max_length_lte,omitempty"`
+	IopsMaxLengthLte *int64 `json:"iops_max_length_lte,omitempty"`
 
 	// iops max length not
-	IopsMaxLengthNot *float64 `json:"iops_max_length_not,omitempty"`
+	IopsMaxLengthNot *int64 `json:"iops_max_length_not,omitempty"`
 
 	// iops max length not in
-	IopsMaxLengthNotIn []float64 `json:"iops_max_length_not_in,omitempty"`
+	IopsMaxLengthNotIn []int64 `json:"iops_max_length_not_in,omitempty"`
 
 	// iops max lt
-	IopsMaxLt *float64 `json:"iops_max_lt,omitempty"`
+	IopsMaxLt *int64 `json:"iops_max_lt,omitempty"`
 
 	// iops max lte
-	IopsMaxLte *float64 `json:"iops_max_lte,omitempty"`
+	IopsMaxLte *int64 `json:"iops_max_lte,omitempty"`
 
 	// iops max not
-	IopsMaxNot *float64 `json:"iops_max_not,omitempty"`
+	IopsMaxNot *int64 `json:"iops_max_not,omitempty"`
 
 	// iops max not in
-	IopsMaxNotIn []float64 `json:"iops_max_not_in,omitempty"`
+	IopsMaxNotIn []int64 `json:"iops_max_not_in,omitempty"`
 
 	// iops not
-	IopsNot *float64 `json:"iops_not,omitempty"`
+	IopsNot *int64 `json:"iops_not,omitempty"`
 
 	// iops not in
-	IopsNotIn []float64 `json:"iops_not_in,omitempty"`
+	IopsNotIn []int64 `json:"iops_not_in,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd gt
-	IopsRdGt *float64 `json:"iops_rd_gt,omitempty"`
+	IopsRdGt *int64 `json:"iops_rd_gt,omitempty"`
 
 	// iops rd gte
-	IopsRdGte *float64 `json:"iops_rd_gte,omitempty"`
+	IopsRdGte *int64 `json:"iops_rd_gte,omitempty"`
 
 	// iops rd in
-	IopsRdIn []float64 `json:"iops_rd_in,omitempty"`
+	IopsRdIn []int64 `json:"iops_rd_in,omitempty"`
 
 	// iops rd lt
-	IopsRdLt *float64 `json:"iops_rd_lt,omitempty"`
+	IopsRdLt *int64 `json:"iops_rd_lt,omitempty"`
 
 	// iops rd lte
-	IopsRdLte *float64 `json:"iops_rd_lte,omitempty"`
+	IopsRdLte *int64 `json:"iops_rd_lte,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max gt
-	IopsRdMaxGt *float64 `json:"iops_rd_max_gt,omitempty"`
+	IopsRdMaxGt *int64 `json:"iops_rd_max_gt,omitempty"`
 
 	// iops rd max gte
-	IopsRdMaxGte *float64 `json:"iops_rd_max_gte,omitempty"`
+	IopsRdMaxGte *int64 `json:"iops_rd_max_gte,omitempty"`
 
 	// iops rd max in
-	IopsRdMaxIn []float64 `json:"iops_rd_max_in,omitempty"`
+	IopsRdMaxIn []int64 `json:"iops_rd_max_in,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops rd max length gt
-	IopsRdMaxLengthGt *float64 `json:"iops_rd_max_length_gt,omitempty"`
+	IopsRdMaxLengthGt *int64 `json:"iops_rd_max_length_gt,omitempty"`
 
 	// iops rd max length gte
-	IopsRdMaxLengthGte *float64 `json:"iops_rd_max_length_gte,omitempty"`
+	IopsRdMaxLengthGte *int64 `json:"iops_rd_max_length_gte,omitempty"`
 
 	// iops rd max length in
-	IopsRdMaxLengthIn []float64 `json:"iops_rd_max_length_in,omitempty"`
+	IopsRdMaxLengthIn []int64 `json:"iops_rd_max_length_in,omitempty"`
 
 	// iops rd max length lt
-	IopsRdMaxLengthLt *float64 `json:"iops_rd_max_length_lt,omitempty"`
+	IopsRdMaxLengthLt *int64 `json:"iops_rd_max_length_lt,omitempty"`
 
 	// iops rd max length lte
-	IopsRdMaxLengthLte *float64 `json:"iops_rd_max_length_lte,omitempty"`
+	IopsRdMaxLengthLte *int64 `json:"iops_rd_max_length_lte,omitempty"`
 
 	// iops rd max length not
-	IopsRdMaxLengthNot *float64 `json:"iops_rd_max_length_not,omitempty"`
+	IopsRdMaxLengthNot *int64 `json:"iops_rd_max_length_not,omitempty"`
 
 	// iops rd max length not in
-	IopsRdMaxLengthNotIn []float64 `json:"iops_rd_max_length_not_in,omitempty"`
+	IopsRdMaxLengthNotIn []int64 `json:"iops_rd_max_length_not_in,omitempty"`
 
 	// iops rd max lt
-	IopsRdMaxLt *float64 `json:"iops_rd_max_lt,omitempty"`
+	IopsRdMaxLt *int64 `json:"iops_rd_max_lt,omitempty"`
 
 	// iops rd max lte
-	IopsRdMaxLte *float64 `json:"iops_rd_max_lte,omitempty"`
+	IopsRdMaxLte *int64 `json:"iops_rd_max_lte,omitempty"`
 
 	// iops rd max not
-	IopsRdMaxNot *float64 `json:"iops_rd_max_not,omitempty"`
+	IopsRdMaxNot *int64 `json:"iops_rd_max_not,omitempty"`
 
 	// iops rd max not in
-	IopsRdMaxNotIn []float64 `json:"iops_rd_max_not_in,omitempty"`
+	IopsRdMaxNotIn []int64 `json:"iops_rd_max_not_in,omitempty"`
 
 	// iops rd not
-	IopsRdNot *float64 `json:"iops_rd_not,omitempty"`
+	IopsRdNot *int64 `json:"iops_rd_not,omitempty"`
 
 	// iops rd not in
-	IopsRdNotIn []float64 `json:"iops_rd_not_in,omitempty"`
+	IopsRdNotIn []int64 `json:"iops_rd_not_in,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr gt
-	IopsWrGt *float64 `json:"iops_wr_gt,omitempty"`
+	IopsWrGt *int64 `json:"iops_wr_gt,omitempty"`
 
 	// iops wr gte
-	IopsWrGte *float64 `json:"iops_wr_gte,omitempty"`
+	IopsWrGte *int64 `json:"iops_wr_gte,omitempty"`
 
 	// iops wr in
-	IopsWrIn []float64 `json:"iops_wr_in,omitempty"`
+	IopsWrIn []int64 `json:"iops_wr_in,omitempty"`
 
 	// iops wr lt
-	IopsWrLt *float64 `json:"iops_wr_lt,omitempty"`
+	IopsWrLt *int64 `json:"iops_wr_lt,omitempty"`
 
 	// iops wr lte
-	IopsWrLte *float64 `json:"iops_wr_lte,omitempty"`
+	IopsWrLte *int64 `json:"iops_wr_lte,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max gt
-	IopsWrMaxGt *float64 `json:"iops_wr_max_gt,omitempty"`
+	IopsWrMaxGt *int64 `json:"iops_wr_max_gt,omitempty"`
 
 	// iops wr max gte
-	IopsWrMaxGte *float64 `json:"iops_wr_max_gte,omitempty"`
+	IopsWrMaxGte *int64 `json:"iops_wr_max_gte,omitempty"`
 
 	// iops wr max in
-	IopsWrMaxIn []float64 `json:"iops_wr_max_in,omitempty"`
+	IopsWrMaxIn []int64 `json:"iops_wr_max_in,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// iops wr max length gt
-	IopsWrMaxLengthGt *float64 `json:"iops_wr_max_length_gt,omitempty"`
+	IopsWrMaxLengthGt *int64 `json:"iops_wr_max_length_gt,omitempty"`
 
 	// iops wr max length gte
-	IopsWrMaxLengthGte *float64 `json:"iops_wr_max_length_gte,omitempty"`
+	IopsWrMaxLengthGte *int64 `json:"iops_wr_max_length_gte,omitempty"`
 
 	// iops wr max length in
-	IopsWrMaxLengthIn []float64 `json:"iops_wr_max_length_in,omitempty"`
+	IopsWrMaxLengthIn []int64 `json:"iops_wr_max_length_in,omitempty"`
 
 	// iops wr max length lt
-	IopsWrMaxLengthLt *float64 `json:"iops_wr_max_length_lt,omitempty"`
+	IopsWrMaxLengthLt *int64 `json:"iops_wr_max_length_lt,omitempty"`
 
 	// iops wr max length lte
-	IopsWrMaxLengthLte *float64 `json:"iops_wr_max_length_lte,omitempty"`
+	IopsWrMaxLengthLte *int64 `json:"iops_wr_max_length_lte,omitempty"`
 
 	// iops wr max length not
-	IopsWrMaxLengthNot *float64 `json:"iops_wr_max_length_not,omitempty"`
+	IopsWrMaxLengthNot *int64 `json:"iops_wr_max_length_not,omitempty"`
 
 	// iops wr max length not in
-	IopsWrMaxLengthNotIn []float64 `json:"iops_wr_max_length_not_in,omitempty"`
+	IopsWrMaxLengthNotIn []int64 `json:"iops_wr_max_length_not_in,omitempty"`
 
 	// iops wr max lt
-	IopsWrMaxLt *float64 `json:"iops_wr_max_lt,omitempty"`
+	IopsWrMaxLt *int64 `json:"iops_wr_max_lt,omitempty"`
 
 	// iops wr max lte
-	IopsWrMaxLte *float64 `json:"iops_wr_max_lte,omitempty"`
+	IopsWrMaxLte *int64 `json:"iops_wr_max_lte,omitempty"`
 
 	// iops wr max not
-	IopsWrMaxNot *float64 `json:"iops_wr_max_not,omitempty"`
+	IopsWrMaxNot *int64 `json:"iops_wr_max_not,omitempty"`
 
 	// iops wr max not in
-	IopsWrMaxNotIn []float64 `json:"iops_wr_max_not_in,omitempty"`
+	IopsWrMaxNotIn []int64 `json:"iops_wr_max_not_in,omitempty"`
 
 	// iops wr not
-	IopsWrNot *float64 `json:"iops_wr_not,omitempty"`
+	IopsWrNot *int64 `json:"iops_wr_not,omitempty"`
 
 	// iops wr not in
-	IopsWrNotIn []float64 `json:"iops_wr_not_in,omitempty"`
+	IopsWrNotIn []int64 `json:"iops_wr_not_in,omitempty"`
 
 	// ip whitelist
 	IPWhitelist *string `json:"ip_whitelist,omitempty"`
@@ -963,28 +963,28 @@ type IscsiTargetWhereInput struct {
 	StripeNumNotIn []int32 `json:"stripe_num_not_in,omitempty"`
 
 	// stripe size
-	StripeSize *float64 `json:"stripe_size,omitempty"`
+	StripeSize *int64 `json:"stripe_size,omitempty"`
 
 	// stripe size gt
-	StripeSizeGt *float64 `json:"stripe_size_gt,omitempty"`
+	StripeSizeGt *int64 `json:"stripe_size_gt,omitempty"`
 
 	// stripe size gte
-	StripeSizeGte *float64 `json:"stripe_size_gte,omitempty"`
+	StripeSizeGte *int64 `json:"stripe_size_gte,omitempty"`
 
 	// stripe size in
-	StripeSizeIn []float64 `json:"stripe_size_in,omitempty"`
+	StripeSizeIn []int64 `json:"stripe_size_in,omitempty"`
 
 	// stripe size lt
-	StripeSizeLt *float64 `json:"stripe_size_lt,omitempty"`
+	StripeSizeLt *int64 `json:"stripe_size_lt,omitempty"`
 
 	// stripe size lte
-	StripeSizeLte *float64 `json:"stripe_size_lte,omitempty"`
+	StripeSizeLte *int64 `json:"stripe_size_lte,omitempty"`
 
 	// stripe size not
-	StripeSizeNot *float64 `json:"stripe_size_not,omitempty"`
+	StripeSizeNot *int64 `json:"stripe_size_not,omitempty"`
 
 	// stripe size not in
-	StripeSizeNotIn []float64 `json:"stripe_size_not_in,omitempty"`
+	StripeSizeNotIn []int64 `json:"stripe_size_not_in,omitempty"`
 
 	// thin provision
 	ThinProvision *bool `json:"thin_provision,omitempty"`

--- a/models/log_collection.go
+++ b/models/log_collection.go
@@ -65,7 +65,7 @@ type LogCollection struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// started at
 	// Required: true

--- a/models/log_collection_where_input.go
+++ b/models/log_collection_where_input.go
@@ -282,28 +282,28 @@ type LogCollectionWhereInput struct {
 	ProgressNotIn []float64 `json:"progress_not_in,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// started at
 	StartedAt *string `json:"started_at,omitempty"`

--- a/models/mount_disks_params.go
+++ b/models/mount_disks_params.go
@@ -35,7 +35,7 @@ type MountDisksParams struct {
 	Key *int32 `json:"key,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`

--- a/models/mount_new_create_disks_params.go
+++ b/models/mount_new_create_disks_params.go
@@ -34,7 +34,7 @@ type MountNewCreateDisksParams struct {
 	Key *int32 `json:"key,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -297,7 +297,7 @@ type MountNewCreateDisksParamsVMVolume struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 }
 
 // Validate validates this mount new create disks params VM volume

--- a/models/nested_discovered_host_disk.go
+++ b/models/nested_discovered_host_disk.go
@@ -45,7 +45,7 @@ type NestedDiscoveredHostDisk struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// type
 	// Required: true

--- a/models/nested_discovered_host_iface.go
+++ b/models/nested_discovered_host_iface.go
@@ -44,7 +44,7 @@ type NestedDiscoveredHostIface struct {
 	RdmaEnabled *bool `json:"rdma_enabled,omitempty"`
 
 	// speed
-	Speed *float64 `json:"speed,omitempty"`
+	Speed *int64 `json:"speed,omitempty"`
 
 	// up
 	// Required: true

--- a/models/nested_disk_failure_information.go
+++ b/models/nested_disk_failure_information.go
@@ -33,7 +33,7 @@ type NestedDiskFailureInformation struct {
 	IostatLatency *bool `json:"iostat_latency,omitempty"`
 
 	// iostat latency ms
-	IostatLatencyMs *float64 `json:"iostat_latency_ms,omitempty"`
+	IostatLatencyMs *int64 `json:"iostat_latency_ms,omitempty"`
 
 	// smart check
 	SmartCheck *bool `json:"smart_check,omitempty"`

--- a/models/nested_everoute_controller_template.go
+++ b/models/nested_everoute_controller_template.go
@@ -29,7 +29,7 @@ type NestedEverouteControllerTemplate struct {
 
 	// memory
 	// Required: true
-	Memory *float64 `json:"memory"`
+	Memory *int64 `json:"memory"`
 
 	// netmask
 	// Required: true
@@ -37,7 +37,7 @@ type NestedEverouteControllerTemplate struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// vcpu
 	// Required: true

--- a/models/nested_frozen_disks.go
+++ b/models/nested_frozen_disks.go
@@ -21,7 +21,7 @@ type NestedFrozenDisks struct {
 
 	// boot
 	// Required: true
-	Boot *float64 `json:"boot"`
+	Boot *int64 `json:"boot"`
 
 	// bus
 	// Required: true
@@ -48,7 +48,7 @@ type NestedFrozenDisks struct {
 	Key *int32 `json:"key,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -65,7 +65,7 @@ type NestedFrozenDisks struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// snapshot local id
 	SnapshotLocalID *string `json:"snapshot_local_id,omitempty"`

--- a/models/nested_frozen_vlan.go
+++ b/models/nested_frozen_vlan.go
@@ -29,7 +29,7 @@ type NestedFrozenVlan struct {
 
 	// vlan id
 	// Required: true
-	VlanID *float64 `json:"vlan_id"`
+	VlanID *int32 `json:"vlan_id"`
 
 	// vlan local id
 	// Required: true

--- a/models/nested_partition.go
+++ b/models/nested_partition.go
@@ -27,7 +27,7 @@ type NestedPartition struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// usage
 	// Required: true
@@ -35,7 +35,7 @@ type NestedPartition struct {
 
 	// used size
 	// Required: true
-	UsedSize *float64 `json:"used_size"`
+	UsedSize *int64 `json:"used_size"`
 }
 
 // Validate validates this nested partition

--- a/models/nfs_inode.go
+++ b/models/nfs_inode.go
@@ -22,7 +22,7 @@ type NfsInode struct {
 
 	// assigned size
 	// Required: true
-	AssignedSize *float64 `json:"assigned_size"`
+	AssignedSize *int64 `json:"assigned_size"`
 
 	// entity async status
 	EntityAsyncStatus *EntityAsyncStatus `json:"entityAsyncStatus,omitempty"`
@@ -60,7 +60,7 @@ type NfsInode struct {
 
 	// shared size
 	// Required: true
-	SharedSize *float64 `json:"shared_size"`
+	SharedSize *int64 `json:"shared_size"`
 
 	// snapshot num
 	// Required: true
@@ -68,7 +68,7 @@ type NfsInode struct {
 
 	// unique size
 	// Required: true
-	UniqueSize *float64 `json:"unique_size"`
+	UniqueSize *int64 `json:"unique_size"`
 }
 
 // Validate validates this nfs inode

--- a/models/nfs_inode_where_input.go
+++ b/models/nfs_inode_where_input.go
@@ -30,28 +30,28 @@ type NfsInodeWhereInput struct {
 	OR []*NfsInodeWhereInput `json:"OR,omitempty"`
 
 	// assigned size
-	AssignedSize *float64 `json:"assigned_size,omitempty"`
+	AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 	// assigned size gt
-	AssignedSizeGt *float64 `json:"assigned_size_gt,omitempty"`
+	AssignedSizeGt *int64 `json:"assigned_size_gt,omitempty"`
 
 	// assigned size gte
-	AssignedSizeGte *float64 `json:"assigned_size_gte,omitempty"`
+	AssignedSizeGte *int64 `json:"assigned_size_gte,omitempty"`
 
 	// assigned size in
-	AssignedSizeIn []float64 `json:"assigned_size_in,omitempty"`
+	AssignedSizeIn []int64 `json:"assigned_size_in,omitempty"`
 
 	// assigned size lt
-	AssignedSizeLt *float64 `json:"assigned_size_lt,omitempty"`
+	AssignedSizeLt *int64 `json:"assigned_size_lt,omitempty"`
 
 	// assigned size lte
-	AssignedSizeLte *float64 `json:"assigned_size_lte,omitempty"`
+	AssignedSizeLte *int64 `json:"assigned_size_lte,omitempty"`
 
 	// assigned size not
-	AssignedSizeNot *float64 `json:"assigned_size_not,omitempty"`
+	AssignedSizeNot *int64 `json:"assigned_size_not,omitempty"`
 
 	// assigned size not in
-	AssignedSizeNotIn []float64 `json:"assigned_size_not_in,omitempty"`
+	AssignedSizeNotIn []int64 `json:"assigned_size_not_in,omitempty"`
 
 	// entity async status
 	EntityAsyncStatus *EntityAsyncStatus `json:"entityAsyncStatus,omitempty"`
@@ -276,28 +276,28 @@ type NfsInodeWhereInput struct {
 	ParentIDStartsWith *string `json:"parent_id_starts_with,omitempty"`
 
 	// shared size
-	SharedSize *float64 `json:"shared_size,omitempty"`
+	SharedSize *int64 `json:"shared_size,omitempty"`
 
 	// shared size gt
-	SharedSizeGt *float64 `json:"shared_size_gt,omitempty"`
+	SharedSizeGt *int64 `json:"shared_size_gt,omitempty"`
 
 	// shared size gte
-	SharedSizeGte *float64 `json:"shared_size_gte,omitempty"`
+	SharedSizeGte *int64 `json:"shared_size_gte,omitempty"`
 
 	// shared size in
-	SharedSizeIn []float64 `json:"shared_size_in,omitempty"`
+	SharedSizeIn []int64 `json:"shared_size_in,omitempty"`
 
 	// shared size lt
-	SharedSizeLt *float64 `json:"shared_size_lt,omitempty"`
+	SharedSizeLt *int64 `json:"shared_size_lt,omitempty"`
 
 	// shared size lte
-	SharedSizeLte *float64 `json:"shared_size_lte,omitempty"`
+	SharedSizeLte *int64 `json:"shared_size_lte,omitempty"`
 
 	// shared size not
-	SharedSizeNot *float64 `json:"shared_size_not,omitempty"`
+	SharedSizeNot *int64 `json:"shared_size_not,omitempty"`
 
 	// shared size not in
-	SharedSizeNotIn []float64 `json:"shared_size_not_in,omitempty"`
+	SharedSizeNotIn []int64 `json:"shared_size_not_in,omitempty"`
 
 	// snapshot num
 	SnapshotNum *int32 `json:"snapshot_num,omitempty"`
@@ -324,28 +324,28 @@ type NfsInodeWhereInput struct {
 	SnapshotNumNotIn []int32 `json:"snapshot_num_not_in,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 }
 
 // Validate validates this nfs inode where input

--- a/models/nic.go
+++ b/models/nic.go
@@ -86,7 +86,7 @@ type Nic struct {
 	Running *bool `json:"running"`
 
 	// speed
-	Speed *float64 `json:"speed,omitempty"`
+	Speed *int64 `json:"speed,omitempty"`
 
 	// subnet mask
 	SubnetMask *string `json:"subnet_mask,omitempty"`

--- a/models/nic_where_input.go
+++ b/models/nic_where_input.go
@@ -546,28 +546,28 @@ type NicWhereInput struct {
 	RunningNot *bool `json:"running_not,omitempty"`
 
 	// speed
-	Speed *float64 `json:"speed,omitempty"`
+	Speed *int64 `json:"speed,omitempty"`
 
 	// speed gt
-	SpeedGt *float64 `json:"speed_gt,omitempty"`
+	SpeedGt *int64 `json:"speed_gt,omitempty"`
 
 	// speed gte
-	SpeedGte *float64 `json:"speed_gte,omitempty"`
+	SpeedGte *int64 `json:"speed_gte,omitempty"`
 
 	// speed in
-	SpeedIn []float64 `json:"speed_in,omitempty"`
+	SpeedIn []int64 `json:"speed_in,omitempty"`
 
 	// speed lt
-	SpeedLt *float64 `json:"speed_lt,omitempty"`
+	SpeedLt *int64 `json:"speed_lt,omitempty"`
 
 	// speed lte
-	SpeedLte *float64 `json:"speed_lte,omitempty"`
+	SpeedLte *int64 `json:"speed_lte,omitempty"`
 
 	// speed not
-	SpeedNot *float64 `json:"speed_not,omitempty"`
+	SpeedNot *int64 `json:"speed_not,omitempty"`
 
 	// speed not in
-	SpeedNotIn []float64 `json:"speed_not_in,omitempty"`
+	SpeedNotIn []int64 `json:"speed_not_in,omitempty"`
 
 	// subnet mask
 	SubnetMask *string `json:"subnet_mask,omitempty"`

--- a/models/nvmf_namespace.go
+++ b/models/nvmf_namespace.go
@@ -22,43 +22,43 @@ type NvmfNamespace struct {
 
 	// assigned size
 	// Required: true
-	AssignedSize *float64 `json:"assigned_size"`
+	AssignedSize *int64 `json:"assigned_size"`
 
 	// bps
 	// Required: true
-	Bps *float64 `json:"bps"`
+	Bps *int64 `json:"bps"`
 
 	// bps max
 	// Required: true
-	BpsMax *float64 `json:"bps_max"`
+	BpsMax *int64 `json:"bps_max"`
 
 	// bps max length
 	// Required: true
-	BpsMaxLength *float64 `json:"bps_max_length"`
+	BpsMaxLength *int64 `json:"bps_max_length"`
 
 	// bps rd
 	// Required: true
-	BpsRd *float64 `json:"bps_rd"`
+	BpsRd *int64 `json:"bps_rd"`
 
 	// bps rd max
 	// Required: true
-	BpsRdMax *float64 `json:"bps_rd_max"`
+	BpsRdMax *int64 `json:"bps_rd_max"`
 
 	// bps rd max length
 	// Required: true
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length"`
 
 	// bps wr
 	// Required: true
-	BpsWr *float64 `json:"bps_wr"`
+	BpsWr *int64 `json:"bps_wr"`
 
 	// bps wr max
 	// Required: true
-	BpsWrMax *float64 `json:"bps_wr_max"`
+	BpsWrMax *int64 `json:"bps_wr_max"`
 
 	// bps wr max length
 	// Required: true
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length"`
 
 	// consistency group
 	ConsistencyGroup *NestedConsistencyGroup `json:"consistency_group,omitempty"`
@@ -72,43 +72,43 @@ type NvmfNamespace struct {
 
 	// io size
 	// Required: true
-	IoSize *float64 `json:"io_size"`
+	IoSize *int64 `json:"io_size"`
 
 	// iops
 	// Required: true
-	Iops *float64 `json:"iops"`
+	Iops *int64 `json:"iops"`
 
 	// iops max
 	// Required: true
-	IopsMax *float64 `json:"iops_max"`
+	IopsMax *int64 `json:"iops_max"`
 
 	// iops max length
 	// Required: true
-	IopsMaxLength *float64 `json:"iops_max_length"`
+	IopsMaxLength *int64 `json:"iops_max_length"`
 
 	// iops rd
 	// Required: true
-	IopsRd *float64 `json:"iops_rd"`
+	IopsRd *int64 `json:"iops_rd"`
 
 	// iops rd max
 	// Required: true
-	IopsRdMax *float64 `json:"iops_rd_max"`
+	IopsRdMax *int64 `json:"iops_rd_max"`
 
 	// iops rd max length
 	// Required: true
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length"`
 
 	// iops wr
 	// Required: true
-	IopsWr *float64 `json:"iops_wr"`
+	IopsWr *int64 `json:"iops_wr"`
 
 	// iops wr max
 	// Required: true
-	IopsWrMax *float64 `json:"iops_wr_max"`
+	IopsWrMax *int64 `json:"iops_wr_max"`
 
 	// iops wr max length
 	// Required: true
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length"`
 
 	// is shared
 	// Required: true
@@ -150,7 +150,7 @@ type NvmfNamespace struct {
 
 	// shared size
 	// Required: true
-	SharedSize *float64 `json:"shared_size"`
+	SharedSize *int64 `json:"shared_size"`
 
 	// snapshot num
 	// Required: true
@@ -162,7 +162,7 @@ type NvmfNamespace struct {
 
 	// stripe size
 	// Required: true
-	StripeSize *float64 `json:"stripe_size"`
+	StripeSize *int64 `json:"stripe_size"`
 
 	// thin provision
 	// Required: true
@@ -170,7 +170,7 @@ type NvmfNamespace struct {
 
 	// unique size
 	// Required: true
-	UniqueSize *float64 `json:"unique_size"`
+	UniqueSize *int64 `json:"unique_size"`
 
 	// zbs volume id
 	// Required: true

--- a/models/nvmf_namespace_common_params.go
+++ b/models/nvmf_namespace_common_params.go
@@ -18,58 +18,58 @@ import (
 type NvmfNamespaceCommonParams struct {
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// nqn whitelist
 	NqnWhitelist *string `json:"nqn_whitelist,omitempty"`

--- a/models/nvmf_namespace_creation_params.go
+++ b/models/nvmf_namespace_creation_params.go
@@ -21,7 +21,7 @@ type NvmfNamespaceCreationParams struct {
 
 	// assigned size
 	// Required: true
-	AssignedSize *float64 `json:"assigned_size"`
+	AssignedSize *int64 `json:"assigned_size"`
 
 	// group id
 	GroupID *string `json:"group_id,omitempty"`
@@ -51,7 +51,7 @@ type NvmfNamespaceCreationParams struct {
 func (m *NvmfNamespaceCreationParams) UnmarshalJSON(raw []byte) error {
 	// AO0
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size"`
+		AssignedSize *int64 `json:"assigned_size"`
 
 		GroupID *string `json:"group_id,omitempty"`
 
@@ -98,7 +98,7 @@ func (m NvmfNamespaceCreationParams) MarshalJSON() ([]byte, error) {
 	_parts := make([][]byte, 0, 2)
 
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size"`
+		AssignedSize *int64 `json:"assigned_size"`
 
 		GroupID *string `json:"group_id,omitempty"`
 

--- a/models/nvmf_namespace_snapshot.go
+++ b/models/nvmf_namespace_snapshot.go
@@ -54,7 +54,7 @@ type NvmfNamespaceSnapshot struct {
 
 	// unique size
 	// Required: true
-	UniqueSize *float64 `json:"unique_size"`
+	UniqueSize *int64 `json:"unique_size"`
 }
 
 // Validate validates this nvmf namespace snapshot

--- a/models/nvmf_namespace_snapshot_where_input.go
+++ b/models/nvmf_namespace_snapshot_where_input.go
@@ -210,28 +210,28 @@ type NvmfNamespaceSnapshotWhereInput struct {
 	NvmfSubsystem *NvmfSubsystemWhereInput `json:"nvmf_subsystem,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 }
 
 // Validate validates this nvmf namespace snapshot where input

--- a/models/nvmf_namespace_updation_params_data.go
+++ b/models/nvmf_namespace_updation_params_data.go
@@ -19,7 +19,7 @@ import (
 type NvmfNamespaceUpdationParamsData struct {
 
 	// assigned size
-	AssignedSize *float64 `json:"assigned_size,omitempty"`
+	AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`
@@ -31,7 +31,7 @@ type NvmfNamespaceUpdationParamsData struct {
 func (m *NvmfNamespaceUpdationParamsData) UnmarshalJSON(raw []byte) error {
 	// AO0
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size,omitempty"`
+		AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 		Name *string `json:"name,omitempty"`
 	}
@@ -58,7 +58,7 @@ func (m NvmfNamespaceUpdationParamsData) MarshalJSON() ([]byte, error) {
 	_parts := make([][]byte, 0, 2)
 
 	var dataAO0 struct {
-		AssignedSize *float64 `json:"assigned_size,omitempty"`
+		AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 		Name *string `json:"name,omitempty"`
 	}

--- a/models/nvmf_namespace_where_input.go
+++ b/models/nvmf_namespace_where_input.go
@@ -30,244 +30,244 @@ type NvmfNamespaceWhereInput struct {
 	OR []*NvmfNamespaceWhereInput `json:"OR,omitempty"`
 
 	// assigned size
-	AssignedSize *float64 `json:"assigned_size,omitempty"`
+	AssignedSize *int64 `json:"assigned_size,omitempty"`
 
 	// assigned size gt
-	AssignedSizeGt *float64 `json:"assigned_size_gt,omitempty"`
+	AssignedSizeGt *int64 `json:"assigned_size_gt,omitempty"`
 
 	// assigned size gte
-	AssignedSizeGte *float64 `json:"assigned_size_gte,omitempty"`
+	AssignedSizeGte *int64 `json:"assigned_size_gte,omitempty"`
 
 	// assigned size in
-	AssignedSizeIn []float64 `json:"assigned_size_in,omitempty"`
+	AssignedSizeIn []int64 `json:"assigned_size_in,omitempty"`
 
 	// assigned size lt
-	AssignedSizeLt *float64 `json:"assigned_size_lt,omitempty"`
+	AssignedSizeLt *int64 `json:"assigned_size_lt,omitempty"`
 
 	// assigned size lte
-	AssignedSizeLte *float64 `json:"assigned_size_lte,omitempty"`
+	AssignedSizeLte *int64 `json:"assigned_size_lte,omitempty"`
 
 	// assigned size not
-	AssignedSizeNot *float64 `json:"assigned_size_not,omitempty"`
+	AssignedSizeNot *int64 `json:"assigned_size_not,omitempty"`
 
 	// assigned size not in
-	AssignedSizeNotIn []float64 `json:"assigned_size_not_in,omitempty"`
+	AssignedSizeNotIn []int64 `json:"assigned_size_not_in,omitempty"`
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps gt
-	BpsGt *float64 `json:"bps_gt,omitempty"`
+	BpsGt *int64 `json:"bps_gt,omitempty"`
 
 	// bps gte
-	BpsGte *float64 `json:"bps_gte,omitempty"`
+	BpsGte *int64 `json:"bps_gte,omitempty"`
 
 	// bps in
-	BpsIn []float64 `json:"bps_in,omitempty"`
+	BpsIn []int64 `json:"bps_in,omitempty"`
 
 	// bps lt
-	BpsLt *float64 `json:"bps_lt,omitempty"`
+	BpsLt *int64 `json:"bps_lt,omitempty"`
 
 	// bps lte
-	BpsLte *float64 `json:"bps_lte,omitempty"`
+	BpsLte *int64 `json:"bps_lte,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max gt
-	BpsMaxGt *float64 `json:"bps_max_gt,omitempty"`
+	BpsMaxGt *int64 `json:"bps_max_gt,omitempty"`
 
 	// bps max gte
-	BpsMaxGte *float64 `json:"bps_max_gte,omitempty"`
+	BpsMaxGte *int64 `json:"bps_max_gte,omitempty"`
 
 	// bps max in
-	BpsMaxIn []float64 `json:"bps_max_in,omitempty"`
+	BpsMaxIn []int64 `json:"bps_max_in,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps max length gt
-	BpsMaxLengthGt *float64 `json:"bps_max_length_gt,omitempty"`
+	BpsMaxLengthGt *int64 `json:"bps_max_length_gt,omitempty"`
 
 	// bps max length gte
-	BpsMaxLengthGte *float64 `json:"bps_max_length_gte,omitempty"`
+	BpsMaxLengthGte *int64 `json:"bps_max_length_gte,omitempty"`
 
 	// bps max length in
-	BpsMaxLengthIn []float64 `json:"bps_max_length_in,omitempty"`
+	BpsMaxLengthIn []int64 `json:"bps_max_length_in,omitempty"`
 
 	// bps max length lt
-	BpsMaxLengthLt *float64 `json:"bps_max_length_lt,omitempty"`
+	BpsMaxLengthLt *int64 `json:"bps_max_length_lt,omitempty"`
 
 	// bps max length lte
-	BpsMaxLengthLte *float64 `json:"bps_max_length_lte,omitempty"`
+	BpsMaxLengthLte *int64 `json:"bps_max_length_lte,omitempty"`
 
 	// bps max length not
-	BpsMaxLengthNot *float64 `json:"bps_max_length_not,omitempty"`
+	BpsMaxLengthNot *int64 `json:"bps_max_length_not,omitempty"`
 
 	// bps max length not in
-	BpsMaxLengthNotIn []float64 `json:"bps_max_length_not_in,omitempty"`
+	BpsMaxLengthNotIn []int64 `json:"bps_max_length_not_in,omitempty"`
 
 	// bps max lt
-	BpsMaxLt *float64 `json:"bps_max_lt,omitempty"`
+	BpsMaxLt *int64 `json:"bps_max_lt,omitempty"`
 
 	// bps max lte
-	BpsMaxLte *float64 `json:"bps_max_lte,omitempty"`
+	BpsMaxLte *int64 `json:"bps_max_lte,omitempty"`
 
 	// bps max not
-	BpsMaxNot *float64 `json:"bps_max_not,omitempty"`
+	BpsMaxNot *int64 `json:"bps_max_not,omitempty"`
 
 	// bps max not in
-	BpsMaxNotIn []float64 `json:"bps_max_not_in,omitempty"`
+	BpsMaxNotIn []int64 `json:"bps_max_not_in,omitempty"`
 
 	// bps not
-	BpsNot *float64 `json:"bps_not,omitempty"`
+	BpsNot *int64 `json:"bps_not,omitempty"`
 
 	// bps not in
-	BpsNotIn []float64 `json:"bps_not_in,omitempty"`
+	BpsNotIn []int64 `json:"bps_not_in,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd gt
-	BpsRdGt *float64 `json:"bps_rd_gt,omitempty"`
+	BpsRdGt *int64 `json:"bps_rd_gt,omitempty"`
 
 	// bps rd gte
-	BpsRdGte *float64 `json:"bps_rd_gte,omitempty"`
+	BpsRdGte *int64 `json:"bps_rd_gte,omitempty"`
 
 	// bps rd in
-	BpsRdIn []float64 `json:"bps_rd_in,omitempty"`
+	BpsRdIn []int64 `json:"bps_rd_in,omitempty"`
 
 	// bps rd lt
-	BpsRdLt *float64 `json:"bps_rd_lt,omitempty"`
+	BpsRdLt *int64 `json:"bps_rd_lt,omitempty"`
 
 	// bps rd lte
-	BpsRdLte *float64 `json:"bps_rd_lte,omitempty"`
+	BpsRdLte *int64 `json:"bps_rd_lte,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max gt
-	BpsRdMaxGt *float64 `json:"bps_rd_max_gt,omitempty"`
+	BpsRdMaxGt *int64 `json:"bps_rd_max_gt,omitempty"`
 
 	// bps rd max gte
-	BpsRdMaxGte *float64 `json:"bps_rd_max_gte,omitempty"`
+	BpsRdMaxGte *int64 `json:"bps_rd_max_gte,omitempty"`
 
 	// bps rd max in
-	BpsRdMaxIn []float64 `json:"bps_rd_max_in,omitempty"`
+	BpsRdMaxIn []int64 `json:"bps_rd_max_in,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps rd max length gt
-	BpsRdMaxLengthGt *float64 `json:"bps_rd_max_length_gt,omitempty"`
+	BpsRdMaxLengthGt *int64 `json:"bps_rd_max_length_gt,omitempty"`
 
 	// bps rd max length gte
-	BpsRdMaxLengthGte *float64 `json:"bps_rd_max_length_gte,omitempty"`
+	BpsRdMaxLengthGte *int64 `json:"bps_rd_max_length_gte,omitempty"`
 
 	// bps rd max length in
-	BpsRdMaxLengthIn []float64 `json:"bps_rd_max_length_in,omitempty"`
+	BpsRdMaxLengthIn []int64 `json:"bps_rd_max_length_in,omitempty"`
 
 	// bps rd max length lt
-	BpsRdMaxLengthLt *float64 `json:"bps_rd_max_length_lt,omitempty"`
+	BpsRdMaxLengthLt *int64 `json:"bps_rd_max_length_lt,omitempty"`
 
 	// bps rd max length lte
-	BpsRdMaxLengthLte *float64 `json:"bps_rd_max_length_lte,omitempty"`
+	BpsRdMaxLengthLte *int64 `json:"bps_rd_max_length_lte,omitempty"`
 
 	// bps rd max length not
-	BpsRdMaxLengthNot *float64 `json:"bps_rd_max_length_not,omitempty"`
+	BpsRdMaxLengthNot *int64 `json:"bps_rd_max_length_not,omitempty"`
 
 	// bps rd max length not in
-	BpsRdMaxLengthNotIn []float64 `json:"bps_rd_max_length_not_in,omitempty"`
+	BpsRdMaxLengthNotIn []int64 `json:"bps_rd_max_length_not_in,omitempty"`
 
 	// bps rd max lt
-	BpsRdMaxLt *float64 `json:"bps_rd_max_lt,omitempty"`
+	BpsRdMaxLt *int64 `json:"bps_rd_max_lt,omitempty"`
 
 	// bps rd max lte
-	BpsRdMaxLte *float64 `json:"bps_rd_max_lte,omitempty"`
+	BpsRdMaxLte *int64 `json:"bps_rd_max_lte,omitempty"`
 
 	// bps rd max not
-	BpsRdMaxNot *float64 `json:"bps_rd_max_not,omitempty"`
+	BpsRdMaxNot *int64 `json:"bps_rd_max_not,omitempty"`
 
 	// bps rd max not in
-	BpsRdMaxNotIn []float64 `json:"bps_rd_max_not_in,omitempty"`
+	BpsRdMaxNotIn []int64 `json:"bps_rd_max_not_in,omitempty"`
 
 	// bps rd not
-	BpsRdNot *float64 `json:"bps_rd_not,omitempty"`
+	BpsRdNot *int64 `json:"bps_rd_not,omitempty"`
 
 	// bps rd not in
-	BpsRdNotIn []float64 `json:"bps_rd_not_in,omitempty"`
+	BpsRdNotIn []int64 `json:"bps_rd_not_in,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr gt
-	BpsWrGt *float64 `json:"bps_wr_gt,omitempty"`
+	BpsWrGt *int64 `json:"bps_wr_gt,omitempty"`
 
 	// bps wr gte
-	BpsWrGte *float64 `json:"bps_wr_gte,omitempty"`
+	BpsWrGte *int64 `json:"bps_wr_gte,omitempty"`
 
 	// bps wr in
-	BpsWrIn []float64 `json:"bps_wr_in,omitempty"`
+	BpsWrIn []int64 `json:"bps_wr_in,omitempty"`
 
 	// bps wr lt
-	BpsWrLt *float64 `json:"bps_wr_lt,omitempty"`
+	BpsWrLt *int64 `json:"bps_wr_lt,omitempty"`
 
 	// bps wr lte
-	BpsWrLte *float64 `json:"bps_wr_lte,omitempty"`
+	BpsWrLte *int64 `json:"bps_wr_lte,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max gt
-	BpsWrMaxGt *float64 `json:"bps_wr_max_gt,omitempty"`
+	BpsWrMaxGt *int64 `json:"bps_wr_max_gt,omitempty"`
 
 	// bps wr max gte
-	BpsWrMaxGte *float64 `json:"bps_wr_max_gte,omitempty"`
+	BpsWrMaxGte *int64 `json:"bps_wr_max_gte,omitempty"`
 
 	// bps wr max in
-	BpsWrMaxIn []float64 `json:"bps_wr_max_in,omitempty"`
+	BpsWrMaxIn []int64 `json:"bps_wr_max_in,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// bps wr max length gt
-	BpsWrMaxLengthGt *float64 `json:"bps_wr_max_length_gt,omitempty"`
+	BpsWrMaxLengthGt *int64 `json:"bps_wr_max_length_gt,omitempty"`
 
 	// bps wr max length gte
-	BpsWrMaxLengthGte *float64 `json:"bps_wr_max_length_gte,omitempty"`
+	BpsWrMaxLengthGte *int64 `json:"bps_wr_max_length_gte,omitempty"`
 
 	// bps wr max length in
-	BpsWrMaxLengthIn []float64 `json:"bps_wr_max_length_in,omitempty"`
+	BpsWrMaxLengthIn []int64 `json:"bps_wr_max_length_in,omitempty"`
 
 	// bps wr max length lt
-	BpsWrMaxLengthLt *float64 `json:"bps_wr_max_length_lt,omitempty"`
+	BpsWrMaxLengthLt *int64 `json:"bps_wr_max_length_lt,omitempty"`
 
 	// bps wr max length lte
-	BpsWrMaxLengthLte *float64 `json:"bps_wr_max_length_lte,omitempty"`
+	BpsWrMaxLengthLte *int64 `json:"bps_wr_max_length_lte,omitempty"`
 
 	// bps wr max length not
-	BpsWrMaxLengthNot *float64 `json:"bps_wr_max_length_not,omitempty"`
+	BpsWrMaxLengthNot *int64 `json:"bps_wr_max_length_not,omitempty"`
 
 	// bps wr max length not in
-	BpsWrMaxLengthNotIn []float64 `json:"bps_wr_max_length_not_in,omitempty"`
+	BpsWrMaxLengthNotIn []int64 `json:"bps_wr_max_length_not_in,omitempty"`
 
 	// bps wr max lt
-	BpsWrMaxLt *float64 `json:"bps_wr_max_lt,omitempty"`
+	BpsWrMaxLt *int64 `json:"bps_wr_max_lt,omitempty"`
 
 	// bps wr max lte
-	BpsWrMaxLte *float64 `json:"bps_wr_max_lte,omitempty"`
+	BpsWrMaxLte *int64 `json:"bps_wr_max_lte,omitempty"`
 
 	// bps wr max not
-	BpsWrMaxNot *float64 `json:"bps_wr_max_not,omitempty"`
+	BpsWrMaxNot *int64 `json:"bps_wr_max_not,omitempty"`
 
 	// bps wr max not in
-	BpsWrMaxNotIn []float64 `json:"bps_wr_max_not_in,omitempty"`
+	BpsWrMaxNotIn []int64 `json:"bps_wr_max_not_in,omitempty"`
 
 	// bps wr not
-	BpsWrNot *float64 `json:"bps_wr_not,omitempty"`
+	BpsWrNot *int64 `json:"bps_wr_not,omitempty"`
 
 	// bps wr not in
-	BpsWrNotIn []float64 `json:"bps_wr_not_in,omitempty"`
+	BpsWrNotIn []int64 `json:"bps_wr_not_in,omitempty"`
 
 	// consistency group
 	ConsistencyGroup *ConsistencyGroupWhereInput `json:"consistency_group,omitempty"`
@@ -327,244 +327,244 @@ type NvmfNamespaceWhereInput struct {
 	IDStartsWith *string `json:"id_starts_with,omitempty"`
 
 	// io size
-	IoSize *float64 `json:"io_size,omitempty"`
+	IoSize *int64 `json:"io_size,omitempty"`
 
 	// io size gt
-	IoSizeGt *float64 `json:"io_size_gt,omitempty"`
+	IoSizeGt *int64 `json:"io_size_gt,omitempty"`
 
 	// io size gte
-	IoSizeGte *float64 `json:"io_size_gte,omitempty"`
+	IoSizeGte *int64 `json:"io_size_gte,omitempty"`
 
 	// io size in
-	IoSizeIn []float64 `json:"io_size_in,omitempty"`
+	IoSizeIn []int64 `json:"io_size_in,omitempty"`
 
 	// io size lt
-	IoSizeLt *float64 `json:"io_size_lt,omitempty"`
+	IoSizeLt *int64 `json:"io_size_lt,omitempty"`
 
 	// io size lte
-	IoSizeLte *float64 `json:"io_size_lte,omitempty"`
+	IoSizeLte *int64 `json:"io_size_lte,omitempty"`
 
 	// io size not
-	IoSizeNot *float64 `json:"io_size_not,omitempty"`
+	IoSizeNot *int64 `json:"io_size_not,omitempty"`
 
 	// io size not in
-	IoSizeNotIn []float64 `json:"io_size_not_in,omitempty"`
+	IoSizeNotIn []int64 `json:"io_size_not_in,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops gt
-	IopsGt *float64 `json:"iops_gt,omitempty"`
+	IopsGt *int64 `json:"iops_gt,omitempty"`
 
 	// iops gte
-	IopsGte *float64 `json:"iops_gte,omitempty"`
+	IopsGte *int64 `json:"iops_gte,omitempty"`
 
 	// iops in
-	IopsIn []float64 `json:"iops_in,omitempty"`
+	IopsIn []int64 `json:"iops_in,omitempty"`
 
 	// iops lt
-	IopsLt *float64 `json:"iops_lt,omitempty"`
+	IopsLt *int64 `json:"iops_lt,omitempty"`
 
 	// iops lte
-	IopsLte *float64 `json:"iops_lte,omitempty"`
+	IopsLte *int64 `json:"iops_lte,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max gt
-	IopsMaxGt *float64 `json:"iops_max_gt,omitempty"`
+	IopsMaxGt *int64 `json:"iops_max_gt,omitempty"`
 
 	// iops max gte
-	IopsMaxGte *float64 `json:"iops_max_gte,omitempty"`
+	IopsMaxGte *int64 `json:"iops_max_gte,omitempty"`
 
 	// iops max in
-	IopsMaxIn []float64 `json:"iops_max_in,omitempty"`
+	IopsMaxIn []int64 `json:"iops_max_in,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops max length gt
-	IopsMaxLengthGt *float64 `json:"iops_max_length_gt,omitempty"`
+	IopsMaxLengthGt *int64 `json:"iops_max_length_gt,omitempty"`
 
 	// iops max length gte
-	IopsMaxLengthGte *float64 `json:"iops_max_length_gte,omitempty"`
+	IopsMaxLengthGte *int64 `json:"iops_max_length_gte,omitempty"`
 
 	// iops max length in
-	IopsMaxLengthIn []float64 `json:"iops_max_length_in,omitempty"`
+	IopsMaxLengthIn []int64 `json:"iops_max_length_in,omitempty"`
 
 	// iops max length lt
-	IopsMaxLengthLt *float64 `json:"iops_max_length_lt,omitempty"`
+	IopsMaxLengthLt *int64 `json:"iops_max_length_lt,omitempty"`
 
 	// iops max length lte
-	IopsMaxLengthLte *float64 `json:"iops_max_length_lte,omitempty"`
+	IopsMaxLengthLte *int64 `json:"iops_max_length_lte,omitempty"`
 
 	// iops max length not
-	IopsMaxLengthNot *float64 `json:"iops_max_length_not,omitempty"`
+	IopsMaxLengthNot *int64 `json:"iops_max_length_not,omitempty"`
 
 	// iops max length not in
-	IopsMaxLengthNotIn []float64 `json:"iops_max_length_not_in,omitempty"`
+	IopsMaxLengthNotIn []int64 `json:"iops_max_length_not_in,omitempty"`
 
 	// iops max lt
-	IopsMaxLt *float64 `json:"iops_max_lt,omitempty"`
+	IopsMaxLt *int64 `json:"iops_max_lt,omitempty"`
 
 	// iops max lte
-	IopsMaxLte *float64 `json:"iops_max_lte,omitempty"`
+	IopsMaxLte *int64 `json:"iops_max_lte,omitempty"`
 
 	// iops max not
-	IopsMaxNot *float64 `json:"iops_max_not,omitempty"`
+	IopsMaxNot *int64 `json:"iops_max_not,omitempty"`
 
 	// iops max not in
-	IopsMaxNotIn []float64 `json:"iops_max_not_in,omitempty"`
+	IopsMaxNotIn []int64 `json:"iops_max_not_in,omitempty"`
 
 	// iops not
-	IopsNot *float64 `json:"iops_not,omitempty"`
+	IopsNot *int64 `json:"iops_not,omitempty"`
 
 	// iops not in
-	IopsNotIn []float64 `json:"iops_not_in,omitempty"`
+	IopsNotIn []int64 `json:"iops_not_in,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd gt
-	IopsRdGt *float64 `json:"iops_rd_gt,omitempty"`
+	IopsRdGt *int64 `json:"iops_rd_gt,omitempty"`
 
 	// iops rd gte
-	IopsRdGte *float64 `json:"iops_rd_gte,omitempty"`
+	IopsRdGte *int64 `json:"iops_rd_gte,omitempty"`
 
 	// iops rd in
-	IopsRdIn []float64 `json:"iops_rd_in,omitempty"`
+	IopsRdIn []int64 `json:"iops_rd_in,omitempty"`
 
 	// iops rd lt
-	IopsRdLt *float64 `json:"iops_rd_lt,omitempty"`
+	IopsRdLt *int64 `json:"iops_rd_lt,omitempty"`
 
 	// iops rd lte
-	IopsRdLte *float64 `json:"iops_rd_lte,omitempty"`
+	IopsRdLte *int64 `json:"iops_rd_lte,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max gt
-	IopsRdMaxGt *float64 `json:"iops_rd_max_gt,omitempty"`
+	IopsRdMaxGt *int64 `json:"iops_rd_max_gt,omitempty"`
 
 	// iops rd max gte
-	IopsRdMaxGte *float64 `json:"iops_rd_max_gte,omitempty"`
+	IopsRdMaxGte *int64 `json:"iops_rd_max_gte,omitempty"`
 
 	// iops rd max in
-	IopsRdMaxIn []float64 `json:"iops_rd_max_in,omitempty"`
+	IopsRdMaxIn []int64 `json:"iops_rd_max_in,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops rd max length gt
-	IopsRdMaxLengthGt *float64 `json:"iops_rd_max_length_gt,omitempty"`
+	IopsRdMaxLengthGt *int64 `json:"iops_rd_max_length_gt,omitempty"`
 
 	// iops rd max length gte
-	IopsRdMaxLengthGte *float64 `json:"iops_rd_max_length_gte,omitempty"`
+	IopsRdMaxLengthGte *int64 `json:"iops_rd_max_length_gte,omitempty"`
 
 	// iops rd max length in
-	IopsRdMaxLengthIn []float64 `json:"iops_rd_max_length_in,omitempty"`
+	IopsRdMaxLengthIn []int64 `json:"iops_rd_max_length_in,omitempty"`
 
 	// iops rd max length lt
-	IopsRdMaxLengthLt *float64 `json:"iops_rd_max_length_lt,omitempty"`
+	IopsRdMaxLengthLt *int64 `json:"iops_rd_max_length_lt,omitempty"`
 
 	// iops rd max length lte
-	IopsRdMaxLengthLte *float64 `json:"iops_rd_max_length_lte,omitempty"`
+	IopsRdMaxLengthLte *int64 `json:"iops_rd_max_length_lte,omitempty"`
 
 	// iops rd max length not
-	IopsRdMaxLengthNot *float64 `json:"iops_rd_max_length_not,omitempty"`
+	IopsRdMaxLengthNot *int64 `json:"iops_rd_max_length_not,omitempty"`
 
 	// iops rd max length not in
-	IopsRdMaxLengthNotIn []float64 `json:"iops_rd_max_length_not_in,omitempty"`
+	IopsRdMaxLengthNotIn []int64 `json:"iops_rd_max_length_not_in,omitempty"`
 
 	// iops rd max lt
-	IopsRdMaxLt *float64 `json:"iops_rd_max_lt,omitempty"`
+	IopsRdMaxLt *int64 `json:"iops_rd_max_lt,omitempty"`
 
 	// iops rd max lte
-	IopsRdMaxLte *float64 `json:"iops_rd_max_lte,omitempty"`
+	IopsRdMaxLte *int64 `json:"iops_rd_max_lte,omitempty"`
 
 	// iops rd max not
-	IopsRdMaxNot *float64 `json:"iops_rd_max_not,omitempty"`
+	IopsRdMaxNot *int64 `json:"iops_rd_max_not,omitempty"`
 
 	// iops rd max not in
-	IopsRdMaxNotIn []float64 `json:"iops_rd_max_not_in,omitempty"`
+	IopsRdMaxNotIn []int64 `json:"iops_rd_max_not_in,omitempty"`
 
 	// iops rd not
-	IopsRdNot *float64 `json:"iops_rd_not,omitempty"`
+	IopsRdNot *int64 `json:"iops_rd_not,omitempty"`
 
 	// iops rd not in
-	IopsRdNotIn []float64 `json:"iops_rd_not_in,omitempty"`
+	IopsRdNotIn []int64 `json:"iops_rd_not_in,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr gt
-	IopsWrGt *float64 `json:"iops_wr_gt,omitempty"`
+	IopsWrGt *int64 `json:"iops_wr_gt,omitempty"`
 
 	// iops wr gte
-	IopsWrGte *float64 `json:"iops_wr_gte,omitempty"`
+	IopsWrGte *int64 `json:"iops_wr_gte,omitempty"`
 
 	// iops wr in
-	IopsWrIn []float64 `json:"iops_wr_in,omitempty"`
+	IopsWrIn []int64 `json:"iops_wr_in,omitempty"`
 
 	// iops wr lt
-	IopsWrLt *float64 `json:"iops_wr_lt,omitempty"`
+	IopsWrLt *int64 `json:"iops_wr_lt,omitempty"`
 
 	// iops wr lte
-	IopsWrLte *float64 `json:"iops_wr_lte,omitempty"`
+	IopsWrLte *int64 `json:"iops_wr_lte,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max gt
-	IopsWrMaxGt *float64 `json:"iops_wr_max_gt,omitempty"`
+	IopsWrMaxGt *int64 `json:"iops_wr_max_gt,omitempty"`
 
 	// iops wr max gte
-	IopsWrMaxGte *float64 `json:"iops_wr_max_gte,omitempty"`
+	IopsWrMaxGte *int64 `json:"iops_wr_max_gte,omitempty"`
 
 	// iops wr max in
-	IopsWrMaxIn []float64 `json:"iops_wr_max_in,omitempty"`
+	IopsWrMaxIn []int64 `json:"iops_wr_max_in,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// iops wr max length gt
-	IopsWrMaxLengthGt *float64 `json:"iops_wr_max_length_gt,omitempty"`
+	IopsWrMaxLengthGt *int64 `json:"iops_wr_max_length_gt,omitempty"`
 
 	// iops wr max length gte
-	IopsWrMaxLengthGte *float64 `json:"iops_wr_max_length_gte,omitempty"`
+	IopsWrMaxLengthGte *int64 `json:"iops_wr_max_length_gte,omitempty"`
 
 	// iops wr max length in
-	IopsWrMaxLengthIn []float64 `json:"iops_wr_max_length_in,omitempty"`
+	IopsWrMaxLengthIn []int64 `json:"iops_wr_max_length_in,omitempty"`
 
 	// iops wr max length lt
-	IopsWrMaxLengthLt *float64 `json:"iops_wr_max_length_lt,omitempty"`
+	IopsWrMaxLengthLt *int64 `json:"iops_wr_max_length_lt,omitempty"`
 
 	// iops wr max length lte
-	IopsWrMaxLengthLte *float64 `json:"iops_wr_max_length_lte,omitempty"`
+	IopsWrMaxLengthLte *int64 `json:"iops_wr_max_length_lte,omitempty"`
 
 	// iops wr max length not
-	IopsWrMaxLengthNot *float64 `json:"iops_wr_max_length_not,omitempty"`
+	IopsWrMaxLengthNot *int64 `json:"iops_wr_max_length_not,omitempty"`
 
 	// iops wr max length not in
-	IopsWrMaxLengthNotIn []float64 `json:"iops_wr_max_length_not_in,omitempty"`
+	IopsWrMaxLengthNotIn []int64 `json:"iops_wr_max_length_not_in,omitempty"`
 
 	// iops wr max lt
-	IopsWrMaxLt *float64 `json:"iops_wr_max_lt,omitempty"`
+	IopsWrMaxLt *int64 `json:"iops_wr_max_lt,omitempty"`
 
 	// iops wr max lte
-	IopsWrMaxLte *float64 `json:"iops_wr_max_lte,omitempty"`
+	IopsWrMaxLte *int64 `json:"iops_wr_max_lte,omitempty"`
 
 	// iops wr max not
-	IopsWrMaxNot *float64 `json:"iops_wr_max_not,omitempty"`
+	IopsWrMaxNot *int64 `json:"iops_wr_max_not,omitempty"`
 
 	// iops wr max not in
-	IopsWrMaxNotIn []float64 `json:"iops_wr_max_not_in,omitempty"`
+	IopsWrMaxNotIn []int64 `json:"iops_wr_max_not_in,omitempty"`
 
 	// iops wr not
-	IopsWrNot *float64 `json:"iops_wr_not,omitempty"`
+	IopsWrNot *int64 `json:"iops_wr_not,omitempty"`
 
 	// iops wr not in
-	IopsWrNotIn []float64 `json:"iops_wr_not_in,omitempty"`
+	IopsWrNotIn []int64 `json:"iops_wr_not_in,omitempty"`
 
 	// is shared
 	IsShared *bool `json:"is_shared,omitempty"`
@@ -786,28 +786,28 @@ type NvmfNamespaceWhereInput struct {
 	ReplicaNumNotIn []int32 `json:"replica_num_not_in,omitempty"`
 
 	// shared size
-	SharedSize *float64 `json:"shared_size,omitempty"`
+	SharedSize *int64 `json:"shared_size,omitempty"`
 
 	// shared size gt
-	SharedSizeGt *float64 `json:"shared_size_gt,omitempty"`
+	SharedSizeGt *int64 `json:"shared_size_gt,omitempty"`
 
 	// shared size gte
-	SharedSizeGte *float64 `json:"shared_size_gte,omitempty"`
+	SharedSizeGte *int64 `json:"shared_size_gte,omitempty"`
 
 	// shared size in
-	SharedSizeIn []float64 `json:"shared_size_in,omitempty"`
+	SharedSizeIn []int64 `json:"shared_size_in,omitempty"`
 
 	// shared size lt
-	SharedSizeLt *float64 `json:"shared_size_lt,omitempty"`
+	SharedSizeLt *int64 `json:"shared_size_lt,omitempty"`
 
 	// shared size lte
-	SharedSizeLte *float64 `json:"shared_size_lte,omitempty"`
+	SharedSizeLte *int64 `json:"shared_size_lte,omitempty"`
 
 	// shared size not
-	SharedSizeNot *float64 `json:"shared_size_not,omitempty"`
+	SharedSizeNot *int64 `json:"shared_size_not,omitempty"`
 
 	// shared size not in
-	SharedSizeNotIn []float64 `json:"shared_size_not_in,omitempty"`
+	SharedSizeNotIn []int64 `json:"shared_size_not_in,omitempty"`
 
 	// snapshot num
 	SnapshotNum *int32 `json:"snapshot_num,omitempty"`
@@ -858,28 +858,28 @@ type NvmfNamespaceWhereInput struct {
 	StripeNumNotIn []int32 `json:"stripe_num_not_in,omitempty"`
 
 	// stripe size
-	StripeSize *float64 `json:"stripe_size,omitempty"`
+	StripeSize *int64 `json:"stripe_size,omitempty"`
 
 	// stripe size gt
-	StripeSizeGt *float64 `json:"stripe_size_gt,omitempty"`
+	StripeSizeGt *int64 `json:"stripe_size_gt,omitempty"`
 
 	// stripe size gte
-	StripeSizeGte *float64 `json:"stripe_size_gte,omitempty"`
+	StripeSizeGte *int64 `json:"stripe_size_gte,omitempty"`
 
 	// stripe size in
-	StripeSizeIn []float64 `json:"stripe_size_in,omitempty"`
+	StripeSizeIn []int64 `json:"stripe_size_in,omitempty"`
 
 	// stripe size lt
-	StripeSizeLt *float64 `json:"stripe_size_lt,omitempty"`
+	StripeSizeLt *int64 `json:"stripe_size_lt,omitempty"`
 
 	// stripe size lte
-	StripeSizeLte *float64 `json:"stripe_size_lte,omitempty"`
+	StripeSizeLte *int64 `json:"stripe_size_lte,omitempty"`
 
 	// stripe size not
-	StripeSizeNot *float64 `json:"stripe_size_not,omitempty"`
+	StripeSizeNot *int64 `json:"stripe_size_not,omitempty"`
 
 	// stripe size not in
-	StripeSizeNotIn []float64 `json:"stripe_size_not_in,omitempty"`
+	StripeSizeNotIn []int64 `json:"stripe_size_not_in,omitempty"`
 
 	// thin provision
 	ThinProvision *bool `json:"thin_provision,omitempty"`
@@ -888,28 +888,28 @@ type NvmfNamespaceWhereInput struct {
 	ThinProvisionNot *bool `json:"thin_provision_not,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 
 	// zbs volume id
 	ZbsVolumeID *string `json:"zbs_volume_id,omitempty"`

--- a/models/nvmf_subsystem.go
+++ b/models/nvmf_subsystem.go
@@ -21,31 +21,31 @@ import (
 type NvmfSubsystem struct {
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// cluster
 	// Required: true
@@ -71,34 +71,34 @@ type NvmfSubsystem struct {
 	Internal *bool `json:"internal"`
 
 	// io size
-	IoSize *float64 `json:"io_size,omitempty"`
+	IoSize *int64 `json:"io_size,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// ip whitelist
 	// Required: true
@@ -143,7 +143,7 @@ type NvmfSubsystem struct {
 
 	// stripe size
 	// Required: true
-	StripeSize *float64 `json:"stripe_size"`
+	StripeSize *int64 `json:"stripe_size"`
 
 	// thin provision
 	// Required: true

--- a/models/nvmf_subsystem_common_params.go
+++ b/models/nvmf_subsystem_common_params.go
@@ -18,61 +18,61 @@ import (
 type NvmfSubsystemCommonParams struct {
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// description
 	Description *string `json:"description,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// ip whitelist
 	IPWhitelist *string `json:"ip_whitelist,omitempty"`

--- a/models/nvmf_subsystem_creation_params.go
+++ b/models/nvmf_subsystem_creation_params.go
@@ -41,7 +41,7 @@ type NvmfSubsystemCreationParams struct {
 
 	// stripe size
 	// Required: true
-	StripeSize *float64 `json:"stripe_size"`
+	StripeSize *int64 `json:"stripe_size"`
 
 	// thin provision
 	// Required: true
@@ -64,7 +64,7 @@ func (m *NvmfSubsystemCreationParams) UnmarshalJSON(raw []byte) error {
 
 		StripeNum *int32 `json:"stripe_num"`
 
-		StripeSize *float64 `json:"stripe_size"`
+		StripeSize *int64 `json:"stripe_size"`
 
 		ThinProvision *bool `json:"thin_provision"`
 	}
@@ -111,7 +111,7 @@ func (m NvmfSubsystemCreationParams) MarshalJSON() ([]byte, error) {
 
 		StripeNum *int32 `json:"stripe_num"`
 
-		StripeSize *float64 `json:"stripe_size"`
+		StripeSize *int64 `json:"stripe_size"`
 
 		ThinProvision *bool `json:"thin_provision"`
 	}

--- a/models/nvmf_subsystem_where_input.go
+++ b/models/nvmf_subsystem_where_input.go
@@ -30,220 +30,220 @@ type NvmfSubsystemWhereInput struct {
 	OR []*NvmfSubsystemWhereInput `json:"OR,omitempty"`
 
 	// bps
-	Bps *float64 `json:"bps,omitempty"`
+	Bps *int64 `json:"bps,omitempty"`
 
 	// bps gt
-	BpsGt *float64 `json:"bps_gt,omitempty"`
+	BpsGt *int64 `json:"bps_gt,omitempty"`
 
 	// bps gte
-	BpsGte *float64 `json:"bps_gte,omitempty"`
+	BpsGte *int64 `json:"bps_gte,omitempty"`
 
 	// bps in
-	BpsIn []float64 `json:"bps_in,omitempty"`
+	BpsIn []int64 `json:"bps_in,omitempty"`
 
 	// bps lt
-	BpsLt *float64 `json:"bps_lt,omitempty"`
+	BpsLt *int64 `json:"bps_lt,omitempty"`
 
 	// bps lte
-	BpsLte *float64 `json:"bps_lte,omitempty"`
+	BpsLte *int64 `json:"bps_lte,omitempty"`
 
 	// bps max
-	BpsMax *float64 `json:"bps_max,omitempty"`
+	BpsMax *int64 `json:"bps_max,omitempty"`
 
 	// bps max gt
-	BpsMaxGt *float64 `json:"bps_max_gt,omitempty"`
+	BpsMaxGt *int64 `json:"bps_max_gt,omitempty"`
 
 	// bps max gte
-	BpsMaxGte *float64 `json:"bps_max_gte,omitempty"`
+	BpsMaxGte *int64 `json:"bps_max_gte,omitempty"`
 
 	// bps max in
-	BpsMaxIn []float64 `json:"bps_max_in,omitempty"`
+	BpsMaxIn []int64 `json:"bps_max_in,omitempty"`
 
 	// bps max length
-	BpsMaxLength *float64 `json:"bps_max_length,omitempty"`
+	BpsMaxLength *int64 `json:"bps_max_length,omitempty"`
 
 	// bps max length gt
-	BpsMaxLengthGt *float64 `json:"bps_max_length_gt,omitempty"`
+	BpsMaxLengthGt *int64 `json:"bps_max_length_gt,omitempty"`
 
 	// bps max length gte
-	BpsMaxLengthGte *float64 `json:"bps_max_length_gte,omitempty"`
+	BpsMaxLengthGte *int64 `json:"bps_max_length_gte,omitempty"`
 
 	// bps max length in
-	BpsMaxLengthIn []float64 `json:"bps_max_length_in,omitempty"`
+	BpsMaxLengthIn []int64 `json:"bps_max_length_in,omitempty"`
 
 	// bps max length lt
-	BpsMaxLengthLt *float64 `json:"bps_max_length_lt,omitempty"`
+	BpsMaxLengthLt *int64 `json:"bps_max_length_lt,omitempty"`
 
 	// bps max length lte
-	BpsMaxLengthLte *float64 `json:"bps_max_length_lte,omitempty"`
+	BpsMaxLengthLte *int64 `json:"bps_max_length_lte,omitempty"`
 
 	// bps max length not
-	BpsMaxLengthNot *float64 `json:"bps_max_length_not,omitempty"`
+	BpsMaxLengthNot *int64 `json:"bps_max_length_not,omitempty"`
 
 	// bps max length not in
-	BpsMaxLengthNotIn []float64 `json:"bps_max_length_not_in,omitempty"`
+	BpsMaxLengthNotIn []int64 `json:"bps_max_length_not_in,omitempty"`
 
 	// bps max lt
-	BpsMaxLt *float64 `json:"bps_max_lt,omitempty"`
+	BpsMaxLt *int64 `json:"bps_max_lt,omitempty"`
 
 	// bps max lte
-	BpsMaxLte *float64 `json:"bps_max_lte,omitempty"`
+	BpsMaxLte *int64 `json:"bps_max_lte,omitempty"`
 
 	// bps max not
-	BpsMaxNot *float64 `json:"bps_max_not,omitempty"`
+	BpsMaxNot *int64 `json:"bps_max_not,omitempty"`
 
 	// bps max not in
-	BpsMaxNotIn []float64 `json:"bps_max_not_in,omitempty"`
+	BpsMaxNotIn []int64 `json:"bps_max_not_in,omitempty"`
 
 	// bps not
-	BpsNot *float64 `json:"bps_not,omitempty"`
+	BpsNot *int64 `json:"bps_not,omitempty"`
 
 	// bps not in
-	BpsNotIn []float64 `json:"bps_not_in,omitempty"`
+	BpsNotIn []int64 `json:"bps_not_in,omitempty"`
 
 	// bps rd
-	BpsRd *float64 `json:"bps_rd,omitempty"`
+	BpsRd *int64 `json:"bps_rd,omitempty"`
 
 	// bps rd gt
-	BpsRdGt *float64 `json:"bps_rd_gt,omitempty"`
+	BpsRdGt *int64 `json:"bps_rd_gt,omitempty"`
 
 	// bps rd gte
-	BpsRdGte *float64 `json:"bps_rd_gte,omitempty"`
+	BpsRdGte *int64 `json:"bps_rd_gte,omitempty"`
 
 	// bps rd in
-	BpsRdIn []float64 `json:"bps_rd_in,omitempty"`
+	BpsRdIn []int64 `json:"bps_rd_in,omitempty"`
 
 	// bps rd lt
-	BpsRdLt *float64 `json:"bps_rd_lt,omitempty"`
+	BpsRdLt *int64 `json:"bps_rd_lt,omitempty"`
 
 	// bps rd lte
-	BpsRdLte *float64 `json:"bps_rd_lte,omitempty"`
+	BpsRdLte *int64 `json:"bps_rd_lte,omitempty"`
 
 	// bps rd max
-	BpsRdMax *float64 `json:"bps_rd_max,omitempty"`
+	BpsRdMax *int64 `json:"bps_rd_max,omitempty"`
 
 	// bps rd max gt
-	BpsRdMaxGt *float64 `json:"bps_rd_max_gt,omitempty"`
+	BpsRdMaxGt *int64 `json:"bps_rd_max_gt,omitempty"`
 
 	// bps rd max gte
-	BpsRdMaxGte *float64 `json:"bps_rd_max_gte,omitempty"`
+	BpsRdMaxGte *int64 `json:"bps_rd_max_gte,omitempty"`
 
 	// bps rd max in
-	BpsRdMaxIn []float64 `json:"bps_rd_max_in,omitempty"`
+	BpsRdMaxIn []int64 `json:"bps_rd_max_in,omitempty"`
 
 	// bps rd max length
-	BpsRdMaxLength *float64 `json:"bps_rd_max_length,omitempty"`
+	BpsRdMaxLength *int64 `json:"bps_rd_max_length,omitempty"`
 
 	// bps rd max length gt
-	BpsRdMaxLengthGt *float64 `json:"bps_rd_max_length_gt,omitempty"`
+	BpsRdMaxLengthGt *int64 `json:"bps_rd_max_length_gt,omitempty"`
 
 	// bps rd max length gte
-	BpsRdMaxLengthGte *float64 `json:"bps_rd_max_length_gte,omitempty"`
+	BpsRdMaxLengthGte *int64 `json:"bps_rd_max_length_gte,omitempty"`
 
 	// bps rd max length in
-	BpsRdMaxLengthIn []float64 `json:"bps_rd_max_length_in,omitempty"`
+	BpsRdMaxLengthIn []int64 `json:"bps_rd_max_length_in,omitempty"`
 
 	// bps rd max length lt
-	BpsRdMaxLengthLt *float64 `json:"bps_rd_max_length_lt,omitempty"`
+	BpsRdMaxLengthLt *int64 `json:"bps_rd_max_length_lt,omitempty"`
 
 	// bps rd max length lte
-	BpsRdMaxLengthLte *float64 `json:"bps_rd_max_length_lte,omitempty"`
+	BpsRdMaxLengthLte *int64 `json:"bps_rd_max_length_lte,omitempty"`
 
 	// bps rd max length not
-	BpsRdMaxLengthNot *float64 `json:"bps_rd_max_length_not,omitempty"`
+	BpsRdMaxLengthNot *int64 `json:"bps_rd_max_length_not,omitempty"`
 
 	// bps rd max length not in
-	BpsRdMaxLengthNotIn []float64 `json:"bps_rd_max_length_not_in,omitempty"`
+	BpsRdMaxLengthNotIn []int64 `json:"bps_rd_max_length_not_in,omitempty"`
 
 	// bps rd max lt
-	BpsRdMaxLt *float64 `json:"bps_rd_max_lt,omitempty"`
+	BpsRdMaxLt *int64 `json:"bps_rd_max_lt,omitempty"`
 
 	// bps rd max lte
-	BpsRdMaxLte *float64 `json:"bps_rd_max_lte,omitempty"`
+	BpsRdMaxLte *int64 `json:"bps_rd_max_lte,omitempty"`
 
 	// bps rd max not
-	BpsRdMaxNot *float64 `json:"bps_rd_max_not,omitempty"`
+	BpsRdMaxNot *int64 `json:"bps_rd_max_not,omitempty"`
 
 	// bps rd max not in
-	BpsRdMaxNotIn []float64 `json:"bps_rd_max_not_in,omitempty"`
+	BpsRdMaxNotIn []int64 `json:"bps_rd_max_not_in,omitempty"`
 
 	// bps rd not
-	BpsRdNot *float64 `json:"bps_rd_not,omitempty"`
+	BpsRdNot *int64 `json:"bps_rd_not,omitempty"`
 
 	// bps rd not in
-	BpsRdNotIn []float64 `json:"bps_rd_not_in,omitempty"`
+	BpsRdNotIn []int64 `json:"bps_rd_not_in,omitempty"`
 
 	// bps wr
-	BpsWr *float64 `json:"bps_wr,omitempty"`
+	BpsWr *int64 `json:"bps_wr,omitempty"`
 
 	// bps wr gt
-	BpsWrGt *float64 `json:"bps_wr_gt,omitempty"`
+	BpsWrGt *int64 `json:"bps_wr_gt,omitempty"`
 
 	// bps wr gte
-	BpsWrGte *float64 `json:"bps_wr_gte,omitempty"`
+	BpsWrGte *int64 `json:"bps_wr_gte,omitempty"`
 
 	// bps wr in
-	BpsWrIn []float64 `json:"bps_wr_in,omitempty"`
+	BpsWrIn []int64 `json:"bps_wr_in,omitempty"`
 
 	// bps wr lt
-	BpsWrLt *float64 `json:"bps_wr_lt,omitempty"`
+	BpsWrLt *int64 `json:"bps_wr_lt,omitempty"`
 
 	// bps wr lte
-	BpsWrLte *float64 `json:"bps_wr_lte,omitempty"`
+	BpsWrLte *int64 `json:"bps_wr_lte,omitempty"`
 
 	// bps wr max
-	BpsWrMax *float64 `json:"bps_wr_max,omitempty"`
+	BpsWrMax *int64 `json:"bps_wr_max,omitempty"`
 
 	// bps wr max gt
-	BpsWrMaxGt *float64 `json:"bps_wr_max_gt,omitempty"`
+	BpsWrMaxGt *int64 `json:"bps_wr_max_gt,omitempty"`
 
 	// bps wr max gte
-	BpsWrMaxGte *float64 `json:"bps_wr_max_gte,omitempty"`
+	BpsWrMaxGte *int64 `json:"bps_wr_max_gte,omitempty"`
 
 	// bps wr max in
-	BpsWrMaxIn []float64 `json:"bps_wr_max_in,omitempty"`
+	BpsWrMaxIn []int64 `json:"bps_wr_max_in,omitempty"`
 
 	// bps wr max length
-	BpsWrMaxLength *float64 `json:"bps_wr_max_length,omitempty"`
+	BpsWrMaxLength *int64 `json:"bps_wr_max_length,omitempty"`
 
 	// bps wr max length gt
-	BpsWrMaxLengthGt *float64 `json:"bps_wr_max_length_gt,omitempty"`
+	BpsWrMaxLengthGt *int64 `json:"bps_wr_max_length_gt,omitempty"`
 
 	// bps wr max length gte
-	BpsWrMaxLengthGte *float64 `json:"bps_wr_max_length_gte,omitempty"`
+	BpsWrMaxLengthGte *int64 `json:"bps_wr_max_length_gte,omitempty"`
 
 	// bps wr max length in
-	BpsWrMaxLengthIn []float64 `json:"bps_wr_max_length_in,omitempty"`
+	BpsWrMaxLengthIn []int64 `json:"bps_wr_max_length_in,omitempty"`
 
 	// bps wr max length lt
-	BpsWrMaxLengthLt *float64 `json:"bps_wr_max_length_lt,omitempty"`
+	BpsWrMaxLengthLt *int64 `json:"bps_wr_max_length_lt,omitempty"`
 
 	// bps wr max length lte
-	BpsWrMaxLengthLte *float64 `json:"bps_wr_max_length_lte,omitempty"`
+	BpsWrMaxLengthLte *int64 `json:"bps_wr_max_length_lte,omitempty"`
 
 	// bps wr max length not
-	BpsWrMaxLengthNot *float64 `json:"bps_wr_max_length_not,omitempty"`
+	BpsWrMaxLengthNot *int64 `json:"bps_wr_max_length_not,omitempty"`
 
 	// bps wr max length not in
-	BpsWrMaxLengthNotIn []float64 `json:"bps_wr_max_length_not_in,omitempty"`
+	BpsWrMaxLengthNotIn []int64 `json:"bps_wr_max_length_not_in,omitempty"`
 
 	// bps wr max lt
-	BpsWrMaxLt *float64 `json:"bps_wr_max_lt,omitempty"`
+	BpsWrMaxLt *int64 `json:"bps_wr_max_lt,omitempty"`
 
 	// bps wr max lte
-	BpsWrMaxLte *float64 `json:"bps_wr_max_lte,omitempty"`
+	BpsWrMaxLte *int64 `json:"bps_wr_max_lte,omitempty"`
 
 	// bps wr max not
-	BpsWrMaxNot *float64 `json:"bps_wr_max_not,omitempty"`
+	BpsWrMaxNot *int64 `json:"bps_wr_max_not,omitempty"`
 
 	// bps wr max not in
-	BpsWrMaxNotIn []float64 `json:"bps_wr_max_not_in,omitempty"`
+	BpsWrMaxNotIn []int64 `json:"bps_wr_max_not_in,omitempty"`
 
 	// bps wr not
-	BpsWrNot *float64 `json:"bps_wr_not,omitempty"`
+	BpsWrNot *int64 `json:"bps_wr_not,omitempty"`
 
 	// bps wr not in
-	BpsWrNotIn []float64 `json:"bps_wr_not_in,omitempty"`
+	BpsWrNotIn []int64 `json:"bps_wr_not_in,omitempty"`
 
 	// cluster
 	Cluster *ClusterWhereInput `json:"cluster,omitempty"`
@@ -357,244 +357,244 @@ type NvmfSubsystemWhereInput struct {
 	InternalNot *bool `json:"internal_not,omitempty"`
 
 	// io size
-	IoSize *float64 `json:"io_size,omitempty"`
+	IoSize *int64 `json:"io_size,omitempty"`
 
 	// io size gt
-	IoSizeGt *float64 `json:"io_size_gt,omitempty"`
+	IoSizeGt *int64 `json:"io_size_gt,omitempty"`
 
 	// io size gte
-	IoSizeGte *float64 `json:"io_size_gte,omitempty"`
+	IoSizeGte *int64 `json:"io_size_gte,omitempty"`
 
 	// io size in
-	IoSizeIn []float64 `json:"io_size_in,omitempty"`
+	IoSizeIn []int64 `json:"io_size_in,omitempty"`
 
 	// io size lt
-	IoSizeLt *float64 `json:"io_size_lt,omitempty"`
+	IoSizeLt *int64 `json:"io_size_lt,omitempty"`
 
 	// io size lte
-	IoSizeLte *float64 `json:"io_size_lte,omitempty"`
+	IoSizeLte *int64 `json:"io_size_lte,omitempty"`
 
 	// io size not
-	IoSizeNot *float64 `json:"io_size_not,omitempty"`
+	IoSizeNot *int64 `json:"io_size_not,omitempty"`
 
 	// io size not in
-	IoSizeNotIn []float64 `json:"io_size_not_in,omitempty"`
+	IoSizeNotIn []int64 `json:"io_size_not_in,omitempty"`
 
 	// iops
-	Iops *float64 `json:"iops,omitempty"`
+	Iops *int64 `json:"iops,omitempty"`
 
 	// iops gt
-	IopsGt *float64 `json:"iops_gt,omitempty"`
+	IopsGt *int64 `json:"iops_gt,omitempty"`
 
 	// iops gte
-	IopsGte *float64 `json:"iops_gte,omitempty"`
+	IopsGte *int64 `json:"iops_gte,omitempty"`
 
 	// iops in
-	IopsIn []float64 `json:"iops_in,omitempty"`
+	IopsIn []int64 `json:"iops_in,omitempty"`
 
 	// iops lt
-	IopsLt *float64 `json:"iops_lt,omitempty"`
+	IopsLt *int64 `json:"iops_lt,omitempty"`
 
 	// iops lte
-	IopsLte *float64 `json:"iops_lte,omitempty"`
+	IopsLte *int64 `json:"iops_lte,omitempty"`
 
 	// iops max
-	IopsMax *float64 `json:"iops_max,omitempty"`
+	IopsMax *int64 `json:"iops_max,omitempty"`
 
 	// iops max gt
-	IopsMaxGt *float64 `json:"iops_max_gt,omitempty"`
+	IopsMaxGt *int64 `json:"iops_max_gt,omitempty"`
 
 	// iops max gte
-	IopsMaxGte *float64 `json:"iops_max_gte,omitempty"`
+	IopsMaxGte *int64 `json:"iops_max_gte,omitempty"`
 
 	// iops max in
-	IopsMaxIn []float64 `json:"iops_max_in,omitempty"`
+	IopsMaxIn []int64 `json:"iops_max_in,omitempty"`
 
 	// iops max length
-	IopsMaxLength *float64 `json:"iops_max_length,omitempty"`
+	IopsMaxLength *int64 `json:"iops_max_length,omitempty"`
 
 	// iops max length gt
-	IopsMaxLengthGt *float64 `json:"iops_max_length_gt,omitempty"`
+	IopsMaxLengthGt *int64 `json:"iops_max_length_gt,omitempty"`
 
 	// iops max length gte
-	IopsMaxLengthGte *float64 `json:"iops_max_length_gte,omitempty"`
+	IopsMaxLengthGte *int64 `json:"iops_max_length_gte,omitempty"`
 
 	// iops max length in
-	IopsMaxLengthIn []float64 `json:"iops_max_length_in,omitempty"`
+	IopsMaxLengthIn []int64 `json:"iops_max_length_in,omitempty"`
 
 	// iops max length lt
-	IopsMaxLengthLt *float64 `json:"iops_max_length_lt,omitempty"`
+	IopsMaxLengthLt *int64 `json:"iops_max_length_lt,omitempty"`
 
 	// iops max length lte
-	IopsMaxLengthLte *float64 `json:"iops_max_length_lte,omitempty"`
+	IopsMaxLengthLte *int64 `json:"iops_max_length_lte,omitempty"`
 
 	// iops max length not
-	IopsMaxLengthNot *float64 `json:"iops_max_length_not,omitempty"`
+	IopsMaxLengthNot *int64 `json:"iops_max_length_not,omitempty"`
 
 	// iops max length not in
-	IopsMaxLengthNotIn []float64 `json:"iops_max_length_not_in,omitempty"`
+	IopsMaxLengthNotIn []int64 `json:"iops_max_length_not_in,omitempty"`
 
 	// iops max lt
-	IopsMaxLt *float64 `json:"iops_max_lt,omitempty"`
+	IopsMaxLt *int64 `json:"iops_max_lt,omitempty"`
 
 	// iops max lte
-	IopsMaxLte *float64 `json:"iops_max_lte,omitempty"`
+	IopsMaxLte *int64 `json:"iops_max_lte,omitempty"`
 
 	// iops max not
-	IopsMaxNot *float64 `json:"iops_max_not,omitempty"`
+	IopsMaxNot *int64 `json:"iops_max_not,omitempty"`
 
 	// iops max not in
-	IopsMaxNotIn []float64 `json:"iops_max_not_in,omitempty"`
+	IopsMaxNotIn []int64 `json:"iops_max_not_in,omitempty"`
 
 	// iops not
-	IopsNot *float64 `json:"iops_not,omitempty"`
+	IopsNot *int64 `json:"iops_not,omitempty"`
 
 	// iops not in
-	IopsNotIn []float64 `json:"iops_not_in,omitempty"`
+	IopsNotIn []int64 `json:"iops_not_in,omitempty"`
 
 	// iops rd
-	IopsRd *float64 `json:"iops_rd,omitempty"`
+	IopsRd *int64 `json:"iops_rd,omitempty"`
 
 	// iops rd gt
-	IopsRdGt *float64 `json:"iops_rd_gt,omitempty"`
+	IopsRdGt *int64 `json:"iops_rd_gt,omitempty"`
 
 	// iops rd gte
-	IopsRdGte *float64 `json:"iops_rd_gte,omitempty"`
+	IopsRdGte *int64 `json:"iops_rd_gte,omitempty"`
 
 	// iops rd in
-	IopsRdIn []float64 `json:"iops_rd_in,omitempty"`
+	IopsRdIn []int64 `json:"iops_rd_in,omitempty"`
 
 	// iops rd lt
-	IopsRdLt *float64 `json:"iops_rd_lt,omitempty"`
+	IopsRdLt *int64 `json:"iops_rd_lt,omitempty"`
 
 	// iops rd lte
-	IopsRdLte *float64 `json:"iops_rd_lte,omitempty"`
+	IopsRdLte *int64 `json:"iops_rd_lte,omitempty"`
 
 	// iops rd max
-	IopsRdMax *float64 `json:"iops_rd_max,omitempty"`
+	IopsRdMax *int64 `json:"iops_rd_max,omitempty"`
 
 	// iops rd max gt
-	IopsRdMaxGt *float64 `json:"iops_rd_max_gt,omitempty"`
+	IopsRdMaxGt *int64 `json:"iops_rd_max_gt,omitempty"`
 
 	// iops rd max gte
-	IopsRdMaxGte *float64 `json:"iops_rd_max_gte,omitempty"`
+	IopsRdMaxGte *int64 `json:"iops_rd_max_gte,omitempty"`
 
 	// iops rd max in
-	IopsRdMaxIn []float64 `json:"iops_rd_max_in,omitempty"`
+	IopsRdMaxIn []int64 `json:"iops_rd_max_in,omitempty"`
 
 	// iops rd max length
-	IopsRdMaxLength *float64 `json:"iops_rd_max_length,omitempty"`
+	IopsRdMaxLength *int64 `json:"iops_rd_max_length,omitempty"`
 
 	// iops rd max length gt
-	IopsRdMaxLengthGt *float64 `json:"iops_rd_max_length_gt,omitempty"`
+	IopsRdMaxLengthGt *int64 `json:"iops_rd_max_length_gt,omitempty"`
 
 	// iops rd max length gte
-	IopsRdMaxLengthGte *float64 `json:"iops_rd_max_length_gte,omitempty"`
+	IopsRdMaxLengthGte *int64 `json:"iops_rd_max_length_gte,omitempty"`
 
 	// iops rd max length in
-	IopsRdMaxLengthIn []float64 `json:"iops_rd_max_length_in,omitempty"`
+	IopsRdMaxLengthIn []int64 `json:"iops_rd_max_length_in,omitempty"`
 
 	// iops rd max length lt
-	IopsRdMaxLengthLt *float64 `json:"iops_rd_max_length_lt,omitempty"`
+	IopsRdMaxLengthLt *int64 `json:"iops_rd_max_length_lt,omitempty"`
 
 	// iops rd max length lte
-	IopsRdMaxLengthLte *float64 `json:"iops_rd_max_length_lte,omitempty"`
+	IopsRdMaxLengthLte *int64 `json:"iops_rd_max_length_lte,omitempty"`
 
 	// iops rd max length not
-	IopsRdMaxLengthNot *float64 `json:"iops_rd_max_length_not,omitempty"`
+	IopsRdMaxLengthNot *int64 `json:"iops_rd_max_length_not,omitempty"`
 
 	// iops rd max length not in
-	IopsRdMaxLengthNotIn []float64 `json:"iops_rd_max_length_not_in,omitempty"`
+	IopsRdMaxLengthNotIn []int64 `json:"iops_rd_max_length_not_in,omitempty"`
 
 	// iops rd max lt
-	IopsRdMaxLt *float64 `json:"iops_rd_max_lt,omitempty"`
+	IopsRdMaxLt *int64 `json:"iops_rd_max_lt,omitempty"`
 
 	// iops rd max lte
-	IopsRdMaxLte *float64 `json:"iops_rd_max_lte,omitempty"`
+	IopsRdMaxLte *int64 `json:"iops_rd_max_lte,omitempty"`
 
 	// iops rd max not
-	IopsRdMaxNot *float64 `json:"iops_rd_max_not,omitempty"`
+	IopsRdMaxNot *int64 `json:"iops_rd_max_not,omitempty"`
 
 	// iops rd max not in
-	IopsRdMaxNotIn []float64 `json:"iops_rd_max_not_in,omitempty"`
+	IopsRdMaxNotIn []int64 `json:"iops_rd_max_not_in,omitempty"`
 
 	// iops rd not
-	IopsRdNot *float64 `json:"iops_rd_not,omitempty"`
+	IopsRdNot *int64 `json:"iops_rd_not,omitempty"`
 
 	// iops rd not in
-	IopsRdNotIn []float64 `json:"iops_rd_not_in,omitempty"`
+	IopsRdNotIn []int64 `json:"iops_rd_not_in,omitempty"`
 
 	// iops wr
-	IopsWr *float64 `json:"iops_wr,omitempty"`
+	IopsWr *int64 `json:"iops_wr,omitempty"`
 
 	// iops wr gt
-	IopsWrGt *float64 `json:"iops_wr_gt,omitempty"`
+	IopsWrGt *int64 `json:"iops_wr_gt,omitempty"`
 
 	// iops wr gte
-	IopsWrGte *float64 `json:"iops_wr_gte,omitempty"`
+	IopsWrGte *int64 `json:"iops_wr_gte,omitempty"`
 
 	// iops wr in
-	IopsWrIn []float64 `json:"iops_wr_in,omitempty"`
+	IopsWrIn []int64 `json:"iops_wr_in,omitempty"`
 
 	// iops wr lt
-	IopsWrLt *float64 `json:"iops_wr_lt,omitempty"`
+	IopsWrLt *int64 `json:"iops_wr_lt,omitempty"`
 
 	// iops wr lte
-	IopsWrLte *float64 `json:"iops_wr_lte,omitempty"`
+	IopsWrLte *int64 `json:"iops_wr_lte,omitempty"`
 
 	// iops wr max
-	IopsWrMax *float64 `json:"iops_wr_max,omitempty"`
+	IopsWrMax *int64 `json:"iops_wr_max,omitempty"`
 
 	// iops wr max gt
-	IopsWrMaxGt *float64 `json:"iops_wr_max_gt,omitempty"`
+	IopsWrMaxGt *int64 `json:"iops_wr_max_gt,omitempty"`
 
 	// iops wr max gte
-	IopsWrMaxGte *float64 `json:"iops_wr_max_gte,omitempty"`
+	IopsWrMaxGte *int64 `json:"iops_wr_max_gte,omitempty"`
 
 	// iops wr max in
-	IopsWrMaxIn []float64 `json:"iops_wr_max_in,omitempty"`
+	IopsWrMaxIn []int64 `json:"iops_wr_max_in,omitempty"`
 
 	// iops wr max length
-	IopsWrMaxLength *float64 `json:"iops_wr_max_length,omitempty"`
+	IopsWrMaxLength *int64 `json:"iops_wr_max_length,omitempty"`
 
 	// iops wr max length gt
-	IopsWrMaxLengthGt *float64 `json:"iops_wr_max_length_gt,omitempty"`
+	IopsWrMaxLengthGt *int64 `json:"iops_wr_max_length_gt,omitempty"`
 
 	// iops wr max length gte
-	IopsWrMaxLengthGte *float64 `json:"iops_wr_max_length_gte,omitempty"`
+	IopsWrMaxLengthGte *int64 `json:"iops_wr_max_length_gte,omitempty"`
 
 	// iops wr max length in
-	IopsWrMaxLengthIn []float64 `json:"iops_wr_max_length_in,omitempty"`
+	IopsWrMaxLengthIn []int64 `json:"iops_wr_max_length_in,omitempty"`
 
 	// iops wr max length lt
-	IopsWrMaxLengthLt *float64 `json:"iops_wr_max_length_lt,omitempty"`
+	IopsWrMaxLengthLt *int64 `json:"iops_wr_max_length_lt,omitempty"`
 
 	// iops wr max length lte
-	IopsWrMaxLengthLte *float64 `json:"iops_wr_max_length_lte,omitempty"`
+	IopsWrMaxLengthLte *int64 `json:"iops_wr_max_length_lte,omitempty"`
 
 	// iops wr max length not
-	IopsWrMaxLengthNot *float64 `json:"iops_wr_max_length_not,omitempty"`
+	IopsWrMaxLengthNot *int64 `json:"iops_wr_max_length_not,omitempty"`
 
 	// iops wr max length not in
-	IopsWrMaxLengthNotIn []float64 `json:"iops_wr_max_length_not_in,omitempty"`
+	IopsWrMaxLengthNotIn []int64 `json:"iops_wr_max_length_not_in,omitempty"`
 
 	// iops wr max lt
-	IopsWrMaxLt *float64 `json:"iops_wr_max_lt,omitempty"`
+	IopsWrMaxLt *int64 `json:"iops_wr_max_lt,omitempty"`
 
 	// iops wr max lte
-	IopsWrMaxLte *float64 `json:"iops_wr_max_lte,omitempty"`
+	IopsWrMaxLte *int64 `json:"iops_wr_max_lte,omitempty"`
 
 	// iops wr max not
-	IopsWrMaxNot *float64 `json:"iops_wr_max_not,omitempty"`
+	IopsWrMaxNot *int64 `json:"iops_wr_max_not,omitempty"`
 
 	// iops wr max not in
-	IopsWrMaxNotIn []float64 `json:"iops_wr_max_not_in,omitempty"`
+	IopsWrMaxNotIn []int64 `json:"iops_wr_max_not_in,omitempty"`
 
 	// iops wr not
-	IopsWrNot *float64 `json:"iops_wr_not,omitempty"`
+	IopsWrNot *int64 `json:"iops_wr_not,omitempty"`
 
 	// iops wr not in
-	IopsWrNotIn []float64 `json:"iops_wr_not_in,omitempty"`
+	IopsWrNotIn []int64 `json:"iops_wr_not_in,omitempty"`
 
 	// ip whitelist
 	IPWhitelist *string `json:"ip_whitelist,omitempty"`
@@ -894,28 +894,28 @@ type NvmfSubsystemWhereInput struct {
 	StripeNumNotIn []int32 `json:"stripe_num_not_in,omitempty"`
 
 	// stripe size
-	StripeSize *float64 `json:"stripe_size,omitempty"`
+	StripeSize *int64 `json:"stripe_size,omitempty"`
 
 	// stripe size gt
-	StripeSizeGt *float64 `json:"stripe_size_gt,omitempty"`
+	StripeSizeGt *int64 `json:"stripe_size_gt,omitempty"`
 
 	// stripe size gte
-	StripeSizeGte *float64 `json:"stripe_size_gte,omitempty"`
+	StripeSizeGte *int64 `json:"stripe_size_gte,omitempty"`
 
 	// stripe size in
-	StripeSizeIn []float64 `json:"stripe_size_in,omitempty"`
+	StripeSizeIn []int64 `json:"stripe_size_in,omitempty"`
 
 	// stripe size lt
-	StripeSizeLt *float64 `json:"stripe_size_lt,omitempty"`
+	StripeSizeLt *int64 `json:"stripe_size_lt,omitempty"`
 
 	// stripe size lte
-	StripeSizeLte *float64 `json:"stripe_size_lte,omitempty"`
+	StripeSizeLte *int64 `json:"stripe_size_lte,omitempty"`
 
 	// stripe size not
-	StripeSizeNot *float64 `json:"stripe_size_not,omitempty"`
+	StripeSizeNot *int64 `json:"stripe_size_not,omitempty"`
 
 	// stripe size not in
-	StripeSizeNotIn []float64 `json:"stripe_size_not_in,omitempty"`
+	StripeSizeNotIn []int64 `json:"stripe_size_not_in,omitempty"`
 
 	// thin provision
 	ThinProvision *bool `json:"thin_provision,omitempty"`

--- a/models/pmem_dimm.go
+++ b/models/pmem_dimm.go
@@ -21,7 +21,7 @@ type PmemDimm struct {
 
 	// capacity
 	// Required: true
-	Capacity *float64 `json:"capacity"`
+	Capacity *int64 `json:"capacity"`
 
 	// device locator
 	// Required: true

--- a/models/pmem_dimm_where_input.go
+++ b/models/pmem_dimm_where_input.go
@@ -30,28 +30,28 @@ type PmemDimmWhereInput struct {
 	OR []*PmemDimmWhereInput `json:"OR,omitempty"`
 
 	// capacity
-	Capacity *float64 `json:"capacity,omitempty"`
+	Capacity *int64 `json:"capacity,omitempty"`
 
 	// capacity gt
-	CapacityGt *float64 `json:"capacity_gt,omitempty"`
+	CapacityGt *int64 `json:"capacity_gt,omitempty"`
 
 	// capacity gte
-	CapacityGte *float64 `json:"capacity_gte,omitempty"`
+	CapacityGte *int64 `json:"capacity_gte,omitempty"`
 
 	// capacity in
-	CapacityIn []float64 `json:"capacity_in,omitempty"`
+	CapacityIn []int64 `json:"capacity_in,omitempty"`
 
 	// capacity lt
-	CapacityLt *float64 `json:"capacity_lt,omitempty"`
+	CapacityLt *int64 `json:"capacity_lt,omitempty"`
 
 	// capacity lte
-	CapacityLte *float64 `json:"capacity_lte,omitempty"`
+	CapacityLte *int64 `json:"capacity_lte,omitempty"`
 
 	// capacity not
-	CapacityNot *float64 `json:"capacity_not,omitempty"`
+	CapacityNot *int64 `json:"capacity_not,omitempty"`
 
 	// capacity not in
-	CapacityNotIn []float64 `json:"capacity_not_in,omitempty"`
+	CapacityNotIn []int64 `json:"capacity_not_in,omitempty"`
 
 	// device locator
 	DeviceLocator *string `json:"device_locator,omitempty"`

--- a/models/snapshot_group.go
+++ b/models/snapshot_group.go
@@ -55,7 +55,7 @@ type SnapshotGroup struct {
 
 	// logical size bytes
 	// Required: true
-	LogicalSizeBytes *float64 `json:"logical_size_bytes"`
+	LogicalSizeBytes *int64 `json:"logical_size_bytes"`
 
 	// name
 	// Required: true

--- a/models/snapshot_group_where_input.go
+++ b/models/snapshot_group_where_input.go
@@ -195,28 +195,28 @@ type SnapshotGroupWhereInput struct {
 	LocalIDStartsWith *string `json:"local_id_starts_with,omitempty"`
 
 	// logical size bytes
-	LogicalSizeBytes *float64 `json:"logical_size_bytes,omitempty"`
+	LogicalSizeBytes *int64 `json:"logical_size_bytes,omitempty"`
 
 	// logical size bytes gt
-	LogicalSizeBytesGt *float64 `json:"logical_size_bytes_gt,omitempty"`
+	LogicalSizeBytesGt *int64 `json:"logical_size_bytes_gt,omitempty"`
 
 	// logical size bytes gte
-	LogicalSizeBytesGte *float64 `json:"logical_size_bytes_gte,omitempty"`
+	LogicalSizeBytesGte *int64 `json:"logical_size_bytes_gte,omitempty"`
 
 	// logical size bytes in
-	LogicalSizeBytesIn []float64 `json:"logical_size_bytes_in,omitempty"`
+	LogicalSizeBytesIn []int64 `json:"logical_size_bytes_in,omitempty"`
 
 	// logical size bytes lt
-	LogicalSizeBytesLt *float64 `json:"logical_size_bytes_lt,omitempty"`
+	LogicalSizeBytesLt *int64 `json:"logical_size_bytes_lt,omitempty"`
 
 	// logical size bytes lte
-	LogicalSizeBytesLte *float64 `json:"logical_size_bytes_lte,omitempty"`
+	LogicalSizeBytesLte *int64 `json:"logical_size_bytes_lte,omitempty"`
 
 	// logical size bytes not
-	LogicalSizeBytesNot *float64 `json:"logical_size_bytes_not,omitempty"`
+	LogicalSizeBytesNot *int64 `json:"logical_size_bytes_not,omitempty"`
 
 	// logical size bytes not in
-	LogicalSizeBytesNotIn []float64 `json:"logical_size_bytes_not_in,omitempty"`
+	LogicalSizeBytesNotIn []int64 `json:"logical_size_bytes_not_in,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`

--- a/models/snapshot_plan.go
+++ b/models/snapshot_plan.go
@@ -80,7 +80,7 @@ type SnapshotPlan struct {
 
 	// logical size bytes
 	// Required: true
-	LogicalSizeBytes *float64 `json:"logical_size_bytes"`
+	LogicalSizeBytes *int64 `json:"logical_size_bytes"`
 
 	// manual delete num
 	// Required: true
@@ -107,7 +107,7 @@ type SnapshotPlan struct {
 
 	// physical size bytes
 	// Required: true
-	PhysicalSizeBytes *float64 `json:"physical_size_bytes"`
+	PhysicalSizeBytes *int64 `json:"physical_size_bytes"`
 
 	// remain snapshot num
 	// Required: true

--- a/models/snapshot_plan_where_input.go
+++ b/models/snapshot_plan_where_input.go
@@ -330,28 +330,28 @@ type SnapshotPlanWhereInput struct {
 	LocalIDStartsWith *string `json:"local_id_starts_with,omitempty"`
 
 	// logical size bytes
-	LogicalSizeBytes *float64 `json:"logical_size_bytes,omitempty"`
+	LogicalSizeBytes *int64 `json:"logical_size_bytes,omitempty"`
 
 	// logical size bytes gt
-	LogicalSizeBytesGt *float64 `json:"logical_size_bytes_gt,omitempty"`
+	LogicalSizeBytesGt *int64 `json:"logical_size_bytes_gt,omitempty"`
 
 	// logical size bytes gte
-	LogicalSizeBytesGte *float64 `json:"logical_size_bytes_gte,omitempty"`
+	LogicalSizeBytesGte *int64 `json:"logical_size_bytes_gte,omitempty"`
 
 	// logical size bytes in
-	LogicalSizeBytesIn []float64 `json:"logical_size_bytes_in,omitempty"`
+	LogicalSizeBytesIn []int64 `json:"logical_size_bytes_in,omitempty"`
 
 	// logical size bytes lt
-	LogicalSizeBytesLt *float64 `json:"logical_size_bytes_lt,omitempty"`
+	LogicalSizeBytesLt *int64 `json:"logical_size_bytes_lt,omitempty"`
 
 	// logical size bytes lte
-	LogicalSizeBytesLte *float64 `json:"logical_size_bytes_lte,omitempty"`
+	LogicalSizeBytesLte *int64 `json:"logical_size_bytes_lte,omitempty"`
 
 	// logical size bytes not
-	LogicalSizeBytesNot *float64 `json:"logical_size_bytes_not,omitempty"`
+	LogicalSizeBytesNot *int64 `json:"logical_size_bytes_not,omitempty"`
 
 	// logical size bytes not in
-	LogicalSizeBytesNotIn []float64 `json:"logical_size_bytes_not_in,omitempty"`
+	LogicalSizeBytesNotIn []int64 `json:"logical_size_bytes_not_in,omitempty"`
 
 	// manual delete num
 	ManualDeleteNum *int32 `json:"manual_delete_num,omitempty"`
@@ -498,28 +498,28 @@ type SnapshotPlanWhereInput struct {
 	ObjectNumNotIn []int32 `json:"object_num_not_in,omitempty"`
 
 	// physical size bytes
-	PhysicalSizeBytes *float64 `json:"physical_size_bytes,omitempty"`
+	PhysicalSizeBytes *int64 `json:"physical_size_bytes,omitempty"`
 
 	// physical size bytes gt
-	PhysicalSizeBytesGt *float64 `json:"physical_size_bytes_gt,omitempty"`
+	PhysicalSizeBytesGt *int64 `json:"physical_size_bytes_gt,omitempty"`
 
 	// physical size bytes gte
-	PhysicalSizeBytesGte *float64 `json:"physical_size_bytes_gte,omitempty"`
+	PhysicalSizeBytesGte *int64 `json:"physical_size_bytes_gte,omitempty"`
 
 	// physical size bytes in
-	PhysicalSizeBytesIn []float64 `json:"physical_size_bytes_in,omitempty"`
+	PhysicalSizeBytesIn []int64 `json:"physical_size_bytes_in,omitempty"`
 
 	// physical size bytes lt
-	PhysicalSizeBytesLt *float64 `json:"physical_size_bytes_lt,omitempty"`
+	PhysicalSizeBytesLt *int64 `json:"physical_size_bytes_lt,omitempty"`
 
 	// physical size bytes lte
-	PhysicalSizeBytesLte *float64 `json:"physical_size_bytes_lte,omitempty"`
+	PhysicalSizeBytesLte *int64 `json:"physical_size_bytes_lte,omitempty"`
 
 	// physical size bytes not
-	PhysicalSizeBytesNot *float64 `json:"physical_size_bytes_not,omitempty"`
+	PhysicalSizeBytesNot *int64 `json:"physical_size_bytes_not,omitempty"`
 
 	// physical size bytes not in
-	PhysicalSizeBytesNotIn []float64 `json:"physical_size_bytes_not_in,omitempty"`
+	PhysicalSizeBytesNotIn []int64 `json:"physical_size_bytes_not_in,omitempty"`
 
 	// remain snapshot num
 	RemainSnapshotNum *int32 `json:"remain_snapshot_num,omitempty"`

--- a/models/svt_image.go
+++ b/models/svt_image.go
@@ -49,7 +49,7 @@ type SvtImage struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// version
 	// Required: true

--- a/models/svt_image_where_input.go
+++ b/models/svt_image_where_input.go
@@ -237,28 +237,28 @@ type SvtImageWhereInput struct {
 	PathStartsWith *string `json:"path_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// version
 	Version *int32 `json:"version,omitempty"`

--- a/models/upload_task.go
+++ b/models/upload_task.go
@@ -25,7 +25,7 @@ type UploadTask struct {
 
 	// chunk size
 	// Required: true
-	ChunkSize *float64 `json:"chunk_size"`
+	ChunkSize *int64 `json:"chunk_size"`
 
 	// current chunk
 	// Required: true
@@ -44,7 +44,7 @@ type UploadTask struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// started at
 	StartedAt *string `json:"started_at,omitempty"`

--- a/models/upload_task_where_input.go
+++ b/models/upload_task_where_input.go
@@ -30,28 +30,28 @@ type UploadTaskWhereInput struct {
 	OR []*UploadTaskWhereInput `json:"OR,omitempty"`
 
 	// chunk size
-	ChunkSize *float64 `json:"chunk_size,omitempty"`
+	ChunkSize *int64 `json:"chunk_size,omitempty"`
 
 	// chunk size gt
-	ChunkSizeGt *float64 `json:"chunk_size_gt,omitempty"`
+	ChunkSizeGt *int64 `json:"chunk_size_gt,omitempty"`
 
 	// chunk size gte
-	ChunkSizeGte *float64 `json:"chunk_size_gte,omitempty"`
+	ChunkSizeGte *int64 `json:"chunk_size_gte,omitempty"`
 
 	// chunk size in
-	ChunkSizeIn []float64 `json:"chunk_size_in,omitempty"`
+	ChunkSizeIn []int64 `json:"chunk_size_in,omitempty"`
 
 	// chunk size lt
-	ChunkSizeLt *float64 `json:"chunk_size_lt,omitempty"`
+	ChunkSizeLt *int64 `json:"chunk_size_lt,omitempty"`
 
 	// chunk size lte
-	ChunkSizeLte *float64 `json:"chunk_size_lte,omitempty"`
+	ChunkSizeLte *int64 `json:"chunk_size_lte,omitempty"`
 
 	// chunk size not
-	ChunkSizeNot *float64 `json:"chunk_size_not,omitempty"`
+	ChunkSizeNot *int64 `json:"chunk_size_not,omitempty"`
 
 	// chunk size not in
-	ChunkSizeNotIn []float64 `json:"chunk_size_not_in,omitempty"`
+	ChunkSizeNotIn []int64 `json:"chunk_size_not_in,omitempty"`
 
 	// current chunk
 	CurrentChunk *int32 `json:"current_chunk,omitempty"`
@@ -156,28 +156,28 @@ type UploadTaskWhereInput struct {
 	ResourceTypeNotIn []UploadResourceType `json:"resource_type_not_in,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// started at
 	StartedAt *string `json:"started_at,omitempty"`

--- a/models/usb_device.go
+++ b/models/usb_device.go
@@ -53,7 +53,7 @@ type UsbDevice struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// status
 	// Required: true

--- a/models/usb_device_where_input.go
+++ b/models/usb_device_where_input.go
@@ -273,28 +273,28 @@ type UsbDeviceWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// status
 	Status *UsbDeviceStatus `json:"status,omitempty"`

--- a/models/vm.go
+++ b/models/vm.go
@@ -74,7 +74,7 @@ type VM struct {
 	GuestSizeUsage *float64 `json:"guest_size_usage,omitempty"`
 
 	// guest used size
-	GuestUsedSize *float64 `json:"guest_used_size,omitempty"`
+	GuestUsedSize *int64 `json:"guest_used_size,omitempty"`
 
 	// ha
 	// Required: true
@@ -128,10 +128,10 @@ type VM struct {
 	LocalID *string `json:"local_id"`
 
 	// logical size bytes
-	LogicalSizeBytes *float64 `json:"logical_size_bytes,omitempty"`
+	LogicalSizeBytes *int64 `json:"logical_size_bytes,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -144,7 +144,7 @@ type VM struct {
 
 	// memory
 	// Required: true
-	Memory *float64 `json:"memory"`
+	Memory *int64 `json:"memory"`
 
 	// memory usage
 	MemoryUsage *float64 `json:"memory_usage,omitempty"`
@@ -176,10 +176,10 @@ type VM struct {
 	Protected *bool `json:"protected"`
 
 	// provisioned size
-	ProvisionedSize *float64 `json:"provisioned_size,omitempty"`
+	ProvisionedSize *int64 `json:"provisioned_size,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// snapshot plan
 	SnapshotPlan *NestedSnapshotPlan `json:"snapshot_plan,omitempty"`
@@ -192,7 +192,7 @@ type VM struct {
 	Status *VMStatus `json:"status"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// usb devices
 	UsbDevices []*NestedUsbDevice `json:"usb_devices,omitempty"`

--- a/models/vm_add_disk_params.go
+++ b/models/vm_add_disk_params.go
@@ -164,7 +164,7 @@ type VMAddDiskParamsData struct {
 	IoPolicy *VMDiskIoPolicy `json:"io_policy,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`

--- a/models/vm_clone_params.go
+++ b/models/vm_clone_params.go
@@ -51,7 +51,7 @@ type VMCloneParams struct {
 	IoPolicy *VMDiskIoPolicy `json:"io_policy,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -63,7 +63,7 @@ type VMCloneParams struct {
 	MaxIopsPolicy *VMDiskIoRestrictType `json:"max_iops_policy,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// name
 	// Required: true

--- a/models/vm_create_vm_from_template_params.go
+++ b/models/vm_create_vm_from_template_params.go
@@ -61,7 +61,7 @@ type VMCreateVMFromTemplateParams struct {
 	IsFullCopy *bool `json:"is_full_copy"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -73,7 +73,7 @@ type VMCreateVMFromTemplateParams struct {
 	MaxIopsPolicy *VMDiskIoRestrictType `json:"max_iops_policy,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// name
 	// Required: true

--- a/models/vm_creation_params.go
+++ b/models/vm_creation_params.go
@@ -56,7 +56,7 @@ type VMCreationParams struct {
 	IoPolicy *VMDiskIoPolicy `json:"io_policy,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -69,7 +69,7 @@ type VMCreationParams struct {
 
 	// memory
 	// Required: true
-	Memory *float64 `json:"memory"`
+	Memory *int64 `json:"memory"`
 
 	// name
 	// Required: true

--- a/models/vm_disk.go
+++ b/models/vm_disk.go
@@ -50,7 +50,7 @@ type VMDisk struct {
 	Key *int32 `json:"key,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`

--- a/models/vm_disk_where_input.go
+++ b/models/vm_disk_where_input.go
@@ -267,28 +267,28 @@ type VMDiskWhereInput struct {
 	KeyNotIn []int32 `json:"key_not_in,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth gt
-	MaxBandwidthGt *float64 `json:"max_bandwidth_gt,omitempty"`
+	MaxBandwidthGt *int64 `json:"max_bandwidth_gt,omitempty"`
 
 	// max bandwidth gte
-	MaxBandwidthGte *float64 `json:"max_bandwidth_gte,omitempty"`
+	MaxBandwidthGte *int64 `json:"max_bandwidth_gte,omitempty"`
 
 	// max bandwidth in
-	MaxBandwidthIn []float64 `json:"max_bandwidth_in,omitempty"`
+	MaxBandwidthIn []int64 `json:"max_bandwidth_in,omitempty"`
 
 	// max bandwidth lt
-	MaxBandwidthLt *float64 `json:"max_bandwidth_lt,omitempty"`
+	MaxBandwidthLt *int64 `json:"max_bandwidth_lt,omitempty"`
 
 	// max bandwidth lte
-	MaxBandwidthLte *float64 `json:"max_bandwidth_lte,omitempty"`
+	MaxBandwidthLte *int64 `json:"max_bandwidth_lte,omitempty"`
 
 	// max bandwidth not
-	MaxBandwidthNot *float64 `json:"max_bandwidth_not,omitempty"`
+	MaxBandwidthNot *int64 `json:"max_bandwidth_not,omitempty"`
 
 	// max bandwidth not in
-	MaxBandwidthNotIn []float64 `json:"max_bandwidth_not_in,omitempty"`
+	MaxBandwidthNotIn []int64 `json:"max_bandwidth_not_in,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`

--- a/models/vm_rebuild_params.go
+++ b/models/vm_rebuild_params.go
@@ -51,7 +51,7 @@ type VMRebuildParams struct {
 	IoPolicy *VMDiskIoPolicy `json:"io_policy,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -63,7 +63,7 @@ type VMRebuildParams struct {
 	MaxIopsPolicy *VMDiskIoRestrictType `json:"max_iops_policy,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// name
 	// Required: true

--- a/models/vm_snapshot.go
+++ b/models/vm_snapshot.go
@@ -73,7 +73,7 @@ type VMSnapshot struct {
 	LocalID *string `json:"local_id"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -86,7 +86,7 @@ type VMSnapshot struct {
 
 	// memory
 	// Required: true
-	Memory *float64 `json:"memory"`
+	Memory *int64 `json:"memory"`
 
 	// name
 	// Required: true
@@ -94,7 +94,7 @@ type VMSnapshot struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// snapshot group
 	SnapshotGroup *NestedSnapshotGroup `json:"snapshot_group,omitempty"`

--- a/models/vm_snapshot_where_input.go
+++ b/models/vm_snapshot_where_input.go
@@ -300,28 +300,28 @@ type VMSnapshotWhereInput struct {
 	LocalIDStartsWith *string `json:"local_id_starts_with,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth gt
-	MaxBandwidthGt *float64 `json:"max_bandwidth_gt,omitempty"`
+	MaxBandwidthGt *int64 `json:"max_bandwidth_gt,omitempty"`
 
 	// max bandwidth gte
-	MaxBandwidthGte *float64 `json:"max_bandwidth_gte,omitempty"`
+	MaxBandwidthGte *int64 `json:"max_bandwidth_gte,omitempty"`
 
 	// max bandwidth in
-	MaxBandwidthIn []float64 `json:"max_bandwidth_in,omitempty"`
+	MaxBandwidthIn []int64 `json:"max_bandwidth_in,omitempty"`
 
 	// max bandwidth lt
-	MaxBandwidthLt *float64 `json:"max_bandwidth_lt,omitempty"`
+	MaxBandwidthLt *int64 `json:"max_bandwidth_lt,omitempty"`
 
 	// max bandwidth lte
-	MaxBandwidthLte *float64 `json:"max_bandwidth_lte,omitempty"`
+	MaxBandwidthLte *int64 `json:"max_bandwidth_lte,omitempty"`
 
 	// max bandwidth not
-	MaxBandwidthNot *float64 `json:"max_bandwidth_not,omitempty"`
+	MaxBandwidthNot *int64 `json:"max_bandwidth_not,omitempty"`
 
 	// max bandwidth not in
-	MaxBandwidthNotIn []float64 `json:"max_bandwidth_not_in,omitempty"`
+	MaxBandwidthNotIn []int64 `json:"max_bandwidth_not_in,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -372,28 +372,28 @@ type VMSnapshotWhereInput struct {
 	MaxIopsPolicyNotIn []VMDiskIoRestrictType `json:"max_iops_policy_not_in,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// memory gt
-	MemoryGt *float64 `json:"memory_gt,omitempty"`
+	MemoryGt *int64 `json:"memory_gt,omitempty"`
 
 	// memory gte
-	MemoryGte *float64 `json:"memory_gte,omitempty"`
+	MemoryGte *int64 `json:"memory_gte,omitempty"`
 
 	// memory in
-	MemoryIn []float64 `json:"memory_in,omitempty"`
+	MemoryIn []int64 `json:"memory_in,omitempty"`
 
 	// memory lt
-	MemoryLt *float64 `json:"memory_lt,omitempty"`
+	MemoryLt *int64 `json:"memory_lt,omitempty"`
 
 	// memory lte
-	MemoryLte *float64 `json:"memory_lte,omitempty"`
+	MemoryLte *int64 `json:"memory_lte,omitempty"`
 
 	// memory not
-	MemoryNot *float64 `json:"memory_not,omitempty"`
+	MemoryNot *int64 `json:"memory_not,omitempty"`
 
 	// memory not in
-	MemoryNotIn []float64 `json:"memory_not_in,omitempty"`
+	MemoryNotIn []int64 `json:"memory_not_in,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`
@@ -438,28 +438,28 @@ type VMSnapshotWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// snapshot group
 	SnapshotGroup *SnapshotGroupWhereInput `json:"snapshot_group,omitempty"`

--- a/models/vm_template.go
+++ b/models/vm_template.go
@@ -76,7 +76,7 @@ type VMTemplate struct {
 	LocalID *string `json:"local_id"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -89,7 +89,7 @@ type VMTemplate struct {
 
 	// memory
 	// Required: true
-	Memory *float64 `json:"memory"`
+	Memory *int64 `json:"memory"`
 
 	// name
 	// Required: true
@@ -97,7 +97,7 @@ type VMTemplate struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// vcpu
 	// Required: true

--- a/models/vm_template_where_input.go
+++ b/models/vm_template_where_input.go
@@ -297,28 +297,28 @@ type VMTemplateWhereInput struct {
 	LocalIDStartsWith *string `json:"local_id_starts_with,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth gt
-	MaxBandwidthGt *float64 `json:"max_bandwidth_gt,omitempty"`
+	MaxBandwidthGt *int64 `json:"max_bandwidth_gt,omitempty"`
 
 	// max bandwidth gte
-	MaxBandwidthGte *float64 `json:"max_bandwidth_gte,omitempty"`
+	MaxBandwidthGte *int64 `json:"max_bandwidth_gte,omitempty"`
 
 	// max bandwidth in
-	MaxBandwidthIn []float64 `json:"max_bandwidth_in,omitempty"`
+	MaxBandwidthIn []int64 `json:"max_bandwidth_in,omitempty"`
 
 	// max bandwidth lt
-	MaxBandwidthLt *float64 `json:"max_bandwidth_lt,omitempty"`
+	MaxBandwidthLt *int64 `json:"max_bandwidth_lt,omitempty"`
 
 	// max bandwidth lte
-	MaxBandwidthLte *float64 `json:"max_bandwidth_lte,omitempty"`
+	MaxBandwidthLte *int64 `json:"max_bandwidth_lte,omitempty"`
 
 	// max bandwidth not
-	MaxBandwidthNot *float64 `json:"max_bandwidth_not,omitempty"`
+	MaxBandwidthNot *int64 `json:"max_bandwidth_not,omitempty"`
 
 	// max bandwidth not in
-	MaxBandwidthNotIn []float64 `json:"max_bandwidth_not_in,omitempty"`
+	MaxBandwidthNotIn []int64 `json:"max_bandwidth_not_in,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -369,28 +369,28 @@ type VMTemplateWhereInput struct {
 	MaxIopsPolicyNotIn []VMDiskIoRestrictType `json:"max_iops_policy_not_in,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// memory gt
-	MemoryGt *float64 `json:"memory_gt,omitempty"`
+	MemoryGt *int64 `json:"memory_gt,omitempty"`
 
 	// memory gte
-	MemoryGte *float64 `json:"memory_gte,omitempty"`
+	MemoryGte *int64 `json:"memory_gte,omitempty"`
 
 	// memory in
-	MemoryIn []float64 `json:"memory_in,omitempty"`
+	MemoryIn []int64 `json:"memory_in,omitempty"`
 
 	// memory lt
-	MemoryLt *float64 `json:"memory_lt,omitempty"`
+	MemoryLt *int64 `json:"memory_lt,omitempty"`
 
 	// memory lte
-	MemoryLte *float64 `json:"memory_lte,omitempty"`
+	MemoryLte *int64 `json:"memory_lte,omitempty"`
 
 	// memory not
-	MemoryNot *float64 `json:"memory_not,omitempty"`
+	MemoryNot *int64 `json:"memory_not,omitempty"`
 
 	// memory not in
-	MemoryNotIn []float64 `json:"memory_not_in,omitempty"`
+	MemoryNotIn []int64 `json:"memory_not_in,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`
@@ -435,28 +435,28 @@ type VMTemplateWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// vcpu
 	Vcpu *int32 `json:"vcpu,omitempty"`

--- a/models/vm_update_params.go
+++ b/models/vm_update_params.go
@@ -172,7 +172,7 @@ type VMUpdateParamsData struct {
 	Ha *bool `json:"ha,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// name
 	Name *string `json:"name,omitempty"`

--- a/models/vm_volume.go
+++ b/models/vm_volume.go
@@ -32,10 +32,10 @@ type VMVolume struct {
 	ElfStoragePolicy *VMVolumeElfStoragePolicyType `json:"elf_storage_policy"`
 
 	// guest size usage
-	GuestSizeUsage *float64 `json:"guest_size_usage,omitempty"`
+	GuestSizeUsage *int64 `json:"guest_size_usage,omitempty"`
 
 	// guest used size
-	GuestUsedSize *float64 `json:"guest_used_size,omitempty"`
+	GuestUsedSize *int64 `json:"guest_used_size,omitempty"`
 
 	// id
 	// Required: true
@@ -73,10 +73,10 @@ type VMVolume struct {
 
 	// size
 	// Required: true
-	Size *float64 `json:"size"`
+	Size *int64 `json:"size"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// vm disks
 	VMDisks []*NestedVMDisk `json:"vm_disks,omitempty"`

--- a/models/vm_volume_creation_params.go
+++ b/models/vm_volume_creation_params.go
@@ -37,7 +37,7 @@ type VMVolumeCreationParams struct {
 
 	// size
 	// Required: true
-	Size *int32 `json:"size"`
+	Size *int64 `json:"size"`
 }
 
 // Validate validates this Vm volume creation params

--- a/models/vm_volume_where_input.go
+++ b/models/vm_volume_where_input.go
@@ -87,52 +87,52 @@ type VMVolumeWhereInput struct {
 	ElfStoragePolicyNotIn []VMVolumeElfStoragePolicyType `json:"elf_storage_policy_not_in,omitempty"`
 
 	// guest size usage
-	GuestSizeUsage *float64 `json:"guest_size_usage,omitempty"`
+	GuestSizeUsage *int64 `json:"guest_size_usage,omitempty"`
 
 	// guest size usage gt
-	GuestSizeUsageGt *float64 `json:"guest_size_usage_gt,omitempty"`
+	GuestSizeUsageGt *int64 `json:"guest_size_usage_gt,omitempty"`
 
 	// guest size usage gte
-	GuestSizeUsageGte *float64 `json:"guest_size_usage_gte,omitempty"`
+	GuestSizeUsageGte *int64 `json:"guest_size_usage_gte,omitempty"`
 
 	// guest size usage in
-	GuestSizeUsageIn []float64 `json:"guest_size_usage_in,omitempty"`
+	GuestSizeUsageIn []int64 `json:"guest_size_usage_in,omitempty"`
 
 	// guest size usage lt
-	GuestSizeUsageLt *float64 `json:"guest_size_usage_lt,omitempty"`
+	GuestSizeUsageLt *int64 `json:"guest_size_usage_lt,omitempty"`
 
 	// guest size usage lte
-	GuestSizeUsageLte *float64 `json:"guest_size_usage_lte,omitempty"`
+	GuestSizeUsageLte *int64 `json:"guest_size_usage_lte,omitempty"`
 
 	// guest size usage not
-	GuestSizeUsageNot *float64 `json:"guest_size_usage_not,omitempty"`
+	GuestSizeUsageNot *int64 `json:"guest_size_usage_not,omitempty"`
 
 	// guest size usage not in
-	GuestSizeUsageNotIn []float64 `json:"guest_size_usage_not_in,omitempty"`
+	GuestSizeUsageNotIn []int64 `json:"guest_size_usage_not_in,omitempty"`
 
 	// guest used size
-	GuestUsedSize *float64 `json:"guest_used_size,omitempty"`
+	GuestUsedSize *int64 `json:"guest_used_size,omitempty"`
 
 	// guest used size gt
-	GuestUsedSizeGt *float64 `json:"guest_used_size_gt,omitempty"`
+	GuestUsedSizeGt *int64 `json:"guest_used_size_gt,omitempty"`
 
 	// guest used size gte
-	GuestUsedSizeGte *float64 `json:"guest_used_size_gte,omitempty"`
+	GuestUsedSizeGte *int64 `json:"guest_used_size_gte,omitempty"`
 
 	// guest used size in
-	GuestUsedSizeIn []float64 `json:"guest_used_size_in,omitempty"`
+	GuestUsedSizeIn []int64 `json:"guest_used_size_in,omitempty"`
 
 	// guest used size lt
-	GuestUsedSizeLt *float64 `json:"guest_used_size_lt,omitempty"`
+	GuestUsedSizeLt *int64 `json:"guest_used_size_lt,omitempty"`
 
 	// guest used size lte
-	GuestUsedSizeLte *float64 `json:"guest_used_size_lte,omitempty"`
+	GuestUsedSizeLte *int64 `json:"guest_used_size_lte,omitempty"`
 
 	// guest used size not
-	GuestUsedSizeNot *float64 `json:"guest_used_size_not,omitempty"`
+	GuestUsedSizeNot *int64 `json:"guest_used_size_not,omitempty"`
 
 	// guest used size not in
-	GuestUsedSizeNotIn []float64 `json:"guest_used_size_not_in,omitempty"`
+	GuestUsedSizeNotIn []int64 `json:"guest_used_size_not_in,omitempty"`
 
 	// id
 	ID *string `json:"id,omitempty"`
@@ -351,52 +351,52 @@ type VMVolumeWhereInput struct {
 	SharingNot *bool `json:"sharing_not,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 
 	// vm disks every
 	VMDisksEvery *VMDiskWhereInput `json:"vm_disks_every,omitempty"`

--- a/models/vm_where_input.go
+++ b/models/vm_where_input.go
@@ -342,28 +342,28 @@ type VMWhereInput struct {
 	GuestSizeUsageNotIn []float64 `json:"guest_size_usage_not_in,omitempty"`
 
 	// guest used size
-	GuestUsedSize *float64 `json:"guest_used_size,omitempty"`
+	GuestUsedSize *int64 `json:"guest_used_size,omitempty"`
 
 	// guest used size gt
-	GuestUsedSizeGt *float64 `json:"guest_used_size_gt,omitempty"`
+	GuestUsedSizeGt *int64 `json:"guest_used_size_gt,omitempty"`
 
 	// guest used size gte
-	GuestUsedSizeGte *float64 `json:"guest_used_size_gte,omitempty"`
+	GuestUsedSizeGte *int64 `json:"guest_used_size_gte,omitempty"`
 
 	// guest used size in
-	GuestUsedSizeIn []float64 `json:"guest_used_size_in,omitempty"`
+	GuestUsedSizeIn []int64 `json:"guest_used_size_in,omitempty"`
 
 	// guest used size lt
-	GuestUsedSizeLt *float64 `json:"guest_used_size_lt,omitempty"`
+	GuestUsedSizeLt *int64 `json:"guest_used_size_lt,omitempty"`
 
 	// guest used size lte
-	GuestUsedSizeLte *float64 `json:"guest_used_size_lte,omitempty"`
+	GuestUsedSizeLte *int64 `json:"guest_used_size_lte,omitempty"`
 
 	// guest used size not
-	GuestUsedSizeNot *float64 `json:"guest_used_size_not,omitempty"`
+	GuestUsedSizeNot *int64 `json:"guest_used_size_not,omitempty"`
 
 	// guest used size not in
-	GuestUsedSizeNotIn []float64 `json:"guest_used_size_not_in,omitempty"`
+	GuestUsedSizeNotIn []int64 `json:"guest_used_size_not_in,omitempty"`
 
 	// ha
 	Ha *bool `json:"ha,omitempty"`
@@ -672,52 +672,52 @@ type VMWhereInput struct {
 	LocalIDStartsWith *string `json:"local_id_starts_with,omitempty"`
 
 	// logical size bytes
-	LogicalSizeBytes *float64 `json:"logical_size_bytes,omitempty"`
+	LogicalSizeBytes *int64 `json:"logical_size_bytes,omitempty"`
 
 	// logical size bytes gt
-	LogicalSizeBytesGt *float64 `json:"logical_size_bytes_gt,omitempty"`
+	LogicalSizeBytesGt *int64 `json:"logical_size_bytes_gt,omitempty"`
 
 	// logical size bytes gte
-	LogicalSizeBytesGte *float64 `json:"logical_size_bytes_gte,omitempty"`
+	LogicalSizeBytesGte *int64 `json:"logical_size_bytes_gte,omitempty"`
 
 	// logical size bytes in
-	LogicalSizeBytesIn []float64 `json:"logical_size_bytes_in,omitempty"`
+	LogicalSizeBytesIn []int64 `json:"logical_size_bytes_in,omitempty"`
 
 	// logical size bytes lt
-	LogicalSizeBytesLt *float64 `json:"logical_size_bytes_lt,omitempty"`
+	LogicalSizeBytesLt *int64 `json:"logical_size_bytes_lt,omitempty"`
 
 	// logical size bytes lte
-	LogicalSizeBytesLte *float64 `json:"logical_size_bytes_lte,omitempty"`
+	LogicalSizeBytesLte *int64 `json:"logical_size_bytes_lte,omitempty"`
 
 	// logical size bytes not
-	LogicalSizeBytesNot *float64 `json:"logical_size_bytes_not,omitempty"`
+	LogicalSizeBytesNot *int64 `json:"logical_size_bytes_not,omitempty"`
 
 	// logical size bytes not in
-	LogicalSizeBytesNotIn []float64 `json:"logical_size_bytes_not_in,omitempty"`
+	LogicalSizeBytesNotIn []int64 `json:"logical_size_bytes_not_in,omitempty"`
 
 	// max bandwidth
-	MaxBandwidth *float64 `json:"max_bandwidth,omitempty"`
+	MaxBandwidth *int64 `json:"max_bandwidth,omitempty"`
 
 	// max bandwidth gt
-	MaxBandwidthGt *float64 `json:"max_bandwidth_gt,omitempty"`
+	MaxBandwidthGt *int64 `json:"max_bandwidth_gt,omitempty"`
 
 	// max bandwidth gte
-	MaxBandwidthGte *float64 `json:"max_bandwidth_gte,omitempty"`
+	MaxBandwidthGte *int64 `json:"max_bandwidth_gte,omitempty"`
 
 	// max bandwidth in
-	MaxBandwidthIn []float64 `json:"max_bandwidth_in,omitempty"`
+	MaxBandwidthIn []int64 `json:"max_bandwidth_in,omitempty"`
 
 	// max bandwidth lt
-	MaxBandwidthLt *float64 `json:"max_bandwidth_lt,omitempty"`
+	MaxBandwidthLt *int64 `json:"max_bandwidth_lt,omitempty"`
 
 	// max bandwidth lte
-	MaxBandwidthLte *float64 `json:"max_bandwidth_lte,omitempty"`
+	MaxBandwidthLte *int64 `json:"max_bandwidth_lte,omitempty"`
 
 	// max bandwidth not
-	MaxBandwidthNot *float64 `json:"max_bandwidth_not,omitempty"`
+	MaxBandwidthNot *int64 `json:"max_bandwidth_not,omitempty"`
 
 	// max bandwidth not in
-	MaxBandwidthNotIn []float64 `json:"max_bandwidth_not_in,omitempty"`
+	MaxBandwidthNotIn []int64 `json:"max_bandwidth_not_in,omitempty"`
 
 	// max bandwidth policy
 	MaxBandwidthPolicy *VMDiskIoRestrictType `json:"max_bandwidth_policy,omitempty"`
@@ -768,28 +768,28 @@ type VMWhereInput struct {
 	MaxIopsPolicyNotIn []VMDiskIoRestrictType `json:"max_iops_policy_not_in,omitempty"`
 
 	// memory
-	Memory *float64 `json:"memory,omitempty"`
+	Memory *int64 `json:"memory,omitempty"`
 
 	// memory gt
-	MemoryGt *float64 `json:"memory_gt,omitempty"`
+	MemoryGt *int64 `json:"memory_gt,omitempty"`
 
 	// memory gte
-	MemoryGte *float64 `json:"memory_gte,omitempty"`
+	MemoryGte *int64 `json:"memory_gte,omitempty"`
 
 	// memory in
-	MemoryIn []float64 `json:"memory_in,omitempty"`
+	MemoryIn []int64 `json:"memory_in,omitempty"`
 
 	// memory lt
-	MemoryLt *float64 `json:"memory_lt,omitempty"`
+	MemoryLt *int64 `json:"memory_lt,omitempty"`
 
 	// memory lte
-	MemoryLte *float64 `json:"memory_lte,omitempty"`
+	MemoryLte *int64 `json:"memory_lte,omitempty"`
 
 	// memory not
-	MemoryNot *float64 `json:"memory_not,omitempty"`
+	MemoryNot *int64 `json:"memory_not,omitempty"`
 
 	// memory not in
-	MemoryNotIn []float64 `json:"memory_not_in,omitempty"`
+	MemoryNotIn []int64 `json:"memory_not_in,omitempty"`
 
 	// memory usage
 	MemoryUsage *float64 `json:"memory_usage,omitempty"`
@@ -996,52 +996,52 @@ type VMWhereInput struct {
 	ProtectedNot *bool `json:"protected_not,omitempty"`
 
 	// provisioned size
-	ProvisionedSize *float64 `json:"provisioned_size,omitempty"`
+	ProvisionedSize *int64 `json:"provisioned_size,omitempty"`
 
 	// provisioned size gt
-	ProvisionedSizeGt *float64 `json:"provisioned_size_gt,omitempty"`
+	ProvisionedSizeGt *int64 `json:"provisioned_size_gt,omitempty"`
 
 	// provisioned size gte
-	ProvisionedSizeGte *float64 `json:"provisioned_size_gte,omitempty"`
+	ProvisionedSizeGte *int64 `json:"provisioned_size_gte,omitempty"`
 
 	// provisioned size in
-	ProvisionedSizeIn []float64 `json:"provisioned_size_in,omitempty"`
+	ProvisionedSizeIn []int64 `json:"provisioned_size_in,omitempty"`
 
 	// provisioned size lt
-	ProvisionedSizeLt *float64 `json:"provisioned_size_lt,omitempty"`
+	ProvisionedSizeLt *int64 `json:"provisioned_size_lt,omitempty"`
 
 	// provisioned size lte
-	ProvisionedSizeLte *float64 `json:"provisioned_size_lte,omitempty"`
+	ProvisionedSizeLte *int64 `json:"provisioned_size_lte,omitempty"`
 
 	// provisioned size not
-	ProvisionedSizeNot *float64 `json:"provisioned_size_not,omitempty"`
+	ProvisionedSizeNot *int64 `json:"provisioned_size_not,omitempty"`
 
 	// provisioned size not in
-	ProvisionedSizeNotIn []float64 `json:"provisioned_size_not_in,omitempty"`
+	ProvisionedSizeNotIn []int64 `json:"provisioned_size_not_in,omitempty"`
 
 	// size
-	Size *float64 `json:"size,omitempty"`
+	Size *int64 `json:"size,omitempty"`
 
 	// size gt
-	SizeGt *float64 `json:"size_gt,omitempty"`
+	SizeGt *int64 `json:"size_gt,omitempty"`
 
 	// size gte
-	SizeGte *float64 `json:"size_gte,omitempty"`
+	SizeGte *int64 `json:"size_gte,omitempty"`
 
 	// size in
-	SizeIn []float64 `json:"size_in,omitempty"`
+	SizeIn []int64 `json:"size_in,omitempty"`
 
 	// size lt
-	SizeLt *float64 `json:"size_lt,omitempty"`
+	SizeLt *int64 `json:"size_lt,omitempty"`
 
 	// size lte
-	SizeLte *float64 `json:"size_lte,omitempty"`
+	SizeLte *int64 `json:"size_lte,omitempty"`
 
 	// size not
-	SizeNot *float64 `json:"size_not,omitempty"`
+	SizeNot *int64 `json:"size_not,omitempty"`
 
 	// size not in
-	SizeNotIn []float64 `json:"size_not_in,omitempty"`
+	SizeNotIn []int64 `json:"size_not_in,omitempty"`
 
 	// snapshot plan
 	SnapshotPlan *SnapshotPlanWhereInput `json:"snapshot_plan,omitempty"`
@@ -1068,28 +1068,28 @@ type VMWhereInput struct {
 	StatusNotIn []VMStatus `json:"status_not_in,omitempty"`
 
 	// unique size
-	UniqueSize *float64 `json:"unique_size,omitempty"`
+	UniqueSize *int64 `json:"unique_size,omitempty"`
 
 	// unique size gt
-	UniqueSizeGt *float64 `json:"unique_size_gt,omitempty"`
+	UniqueSizeGt *int64 `json:"unique_size_gt,omitempty"`
 
 	// unique size gte
-	UniqueSizeGte *float64 `json:"unique_size_gte,omitempty"`
+	UniqueSizeGte *int64 `json:"unique_size_gte,omitempty"`
 
 	// unique size in
-	UniqueSizeIn []float64 `json:"unique_size_in,omitempty"`
+	UniqueSizeIn []int64 `json:"unique_size_in,omitempty"`
 
 	// unique size lt
-	UniqueSizeLt *float64 `json:"unique_size_lt,omitempty"`
+	UniqueSizeLt *int64 `json:"unique_size_lt,omitempty"`
 
 	// unique size lte
-	UniqueSizeLte *float64 `json:"unique_size_lte,omitempty"`
+	UniqueSizeLte *int64 `json:"unique_size_lte,omitempty"`
 
 	// unique size not
-	UniqueSizeNot *float64 `json:"unique_size_not,omitempty"`
+	UniqueSizeNot *int64 `json:"unique_size_not,omitempty"`
 
 	// unique size not in
-	UniqueSizeNotIn []float64 `json:"unique_size_not_in,omitempty"`
+	UniqueSizeNotIn []int64 `json:"unique_size_not_in,omitempty"`
 
 	// usb devices every
 	UsbDevicesEvery *UsbDeviceWhereInput `json:"usb_devices_every,omitempty"`

--- a/models/witness.go
+++ b/models/witness.go
@@ -25,7 +25,7 @@ type Witness struct {
 
 	// cpu hz per core
 	// Required: true
-	CPUHzPerCore *float64 `json:"cpu_hz_per_core"`
+	CPUHzPerCore *int64 `json:"cpu_hz_per_core"`
 
 	// data ip
 	// Required: true
@@ -44,11 +44,11 @@ type Witness struct {
 
 	// system data capacity
 	// Required: true
-	SystemDataCapacity *float64 `json:"system_data_capacity"`
+	SystemDataCapacity *int64 `json:"system_data_capacity"`
 
 	// system used data space
 	// Required: true
-	SystemUsedDataSpace *float64 `json:"system_used_data_space"`
+	SystemUsedDataSpace *int64 `json:"system_used_data_space"`
 
 	// total cpu cores
 	// Required: true
@@ -56,11 +56,11 @@ type Witness struct {
 
 	// total cpu hz
 	// Required: true
-	TotalCPUHz *float64 `json:"total_cpu_hz"`
+	TotalCPUHz *int64 `json:"total_cpu_hz"`
 
 	// total memory bytes
 	// Required: true
-	TotalMemoryBytes *float64 `json:"total_memory_bytes"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes"`
 }
 
 // Validate validates this witness

--- a/models/witness_service.go
+++ b/models/witness_service.go
@@ -37,7 +37,7 @@ type WitnessService struct {
 
 	// state duration
 	// Required: true
-	StateDuration *float64 `json:"state_duration"`
+	StateDuration *int64 `json:"state_duration"`
 }
 
 // Validate validates this witness service

--- a/models/witness_where_input.go
+++ b/models/witness_where_input.go
@@ -33,28 +33,28 @@ type WitnessWhereInput struct {
 	Cluster *ClusterWhereInput `json:"cluster,omitempty"`
 
 	// cpu hz per core
-	CPUHzPerCore *float64 `json:"cpu_hz_per_core,omitempty"`
+	CPUHzPerCore *int64 `json:"cpu_hz_per_core,omitempty"`
 
 	// cpu hz per core gt
-	CPUHzPerCoreGt *float64 `json:"cpu_hz_per_core_gt,omitempty"`
+	CPUHzPerCoreGt *int64 `json:"cpu_hz_per_core_gt,omitempty"`
 
 	// cpu hz per core gte
-	CPUHzPerCoreGte *float64 `json:"cpu_hz_per_core_gte,omitempty"`
+	CPUHzPerCoreGte *int64 `json:"cpu_hz_per_core_gte,omitempty"`
 
 	// cpu hz per core in
-	CPUHzPerCoreIn []float64 `json:"cpu_hz_per_core_in,omitempty"`
+	CPUHzPerCoreIn []int64 `json:"cpu_hz_per_core_in,omitempty"`
 
 	// cpu hz per core lt
-	CPUHzPerCoreLt *float64 `json:"cpu_hz_per_core_lt,omitempty"`
+	CPUHzPerCoreLt *int64 `json:"cpu_hz_per_core_lt,omitempty"`
 
 	// cpu hz per core lte
-	CPUHzPerCoreLte *float64 `json:"cpu_hz_per_core_lte,omitempty"`
+	CPUHzPerCoreLte *int64 `json:"cpu_hz_per_core_lte,omitempty"`
 
 	// cpu hz per core not
-	CPUHzPerCoreNot *float64 `json:"cpu_hz_per_core_not,omitempty"`
+	CPUHzPerCoreNot *int64 `json:"cpu_hz_per_core_not,omitempty"`
 
 	// cpu hz per core not in
-	CPUHzPerCoreNotIn []float64 `json:"cpu_hz_per_core_not_in,omitempty"`
+	CPUHzPerCoreNotIn []int64 `json:"cpu_hz_per_core_not_in,omitempty"`
 
 	// data ip
 	DataIP *string `json:"data_ip,omitempty"`
@@ -225,52 +225,52 @@ type WitnessWhereInput struct {
 	NameStartsWith *string `json:"name_starts_with,omitempty"`
 
 	// system data capacity
-	SystemDataCapacity *float64 `json:"system_data_capacity,omitempty"`
+	SystemDataCapacity *int64 `json:"system_data_capacity,omitempty"`
 
 	// system data capacity gt
-	SystemDataCapacityGt *float64 `json:"system_data_capacity_gt,omitempty"`
+	SystemDataCapacityGt *int64 `json:"system_data_capacity_gt,omitempty"`
 
 	// system data capacity gte
-	SystemDataCapacityGte *float64 `json:"system_data_capacity_gte,omitempty"`
+	SystemDataCapacityGte *int64 `json:"system_data_capacity_gte,omitempty"`
 
 	// system data capacity in
-	SystemDataCapacityIn []float64 `json:"system_data_capacity_in,omitempty"`
+	SystemDataCapacityIn []int64 `json:"system_data_capacity_in,omitempty"`
 
 	// system data capacity lt
-	SystemDataCapacityLt *float64 `json:"system_data_capacity_lt,omitempty"`
+	SystemDataCapacityLt *int64 `json:"system_data_capacity_lt,omitempty"`
 
 	// system data capacity lte
-	SystemDataCapacityLte *float64 `json:"system_data_capacity_lte,omitempty"`
+	SystemDataCapacityLte *int64 `json:"system_data_capacity_lte,omitempty"`
 
 	// system data capacity not
-	SystemDataCapacityNot *float64 `json:"system_data_capacity_not,omitempty"`
+	SystemDataCapacityNot *int64 `json:"system_data_capacity_not,omitempty"`
 
 	// system data capacity not in
-	SystemDataCapacityNotIn []float64 `json:"system_data_capacity_not_in,omitempty"`
+	SystemDataCapacityNotIn []int64 `json:"system_data_capacity_not_in,omitempty"`
 
 	// system used data space
-	SystemUsedDataSpace *float64 `json:"system_used_data_space,omitempty"`
+	SystemUsedDataSpace *int64 `json:"system_used_data_space,omitempty"`
 
 	// system used data space gt
-	SystemUsedDataSpaceGt *float64 `json:"system_used_data_space_gt,omitempty"`
+	SystemUsedDataSpaceGt *int64 `json:"system_used_data_space_gt,omitempty"`
 
 	// system used data space gte
-	SystemUsedDataSpaceGte *float64 `json:"system_used_data_space_gte,omitempty"`
+	SystemUsedDataSpaceGte *int64 `json:"system_used_data_space_gte,omitempty"`
 
 	// system used data space in
-	SystemUsedDataSpaceIn []float64 `json:"system_used_data_space_in,omitempty"`
+	SystemUsedDataSpaceIn []int64 `json:"system_used_data_space_in,omitempty"`
 
 	// system used data space lt
-	SystemUsedDataSpaceLt *float64 `json:"system_used_data_space_lt,omitempty"`
+	SystemUsedDataSpaceLt *int64 `json:"system_used_data_space_lt,omitempty"`
 
 	// system used data space lte
-	SystemUsedDataSpaceLte *float64 `json:"system_used_data_space_lte,omitempty"`
+	SystemUsedDataSpaceLte *int64 `json:"system_used_data_space_lte,omitempty"`
 
 	// system used data space not
-	SystemUsedDataSpaceNot *float64 `json:"system_used_data_space_not,omitempty"`
+	SystemUsedDataSpaceNot *int64 `json:"system_used_data_space_not,omitempty"`
 
 	// system used data space not in
-	SystemUsedDataSpaceNotIn []float64 `json:"system_used_data_space_not_in,omitempty"`
+	SystemUsedDataSpaceNotIn []int64 `json:"system_used_data_space_not_in,omitempty"`
 
 	// total cpu cores
 	TotalCPUCores *int32 `json:"total_cpu_cores,omitempty"`
@@ -297,52 +297,52 @@ type WitnessWhereInput struct {
 	TotalCPUCoresNotIn []int32 `json:"total_cpu_cores_not_in,omitempty"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total cpu hz gt
-	TotalCPUHzGt *float64 `json:"total_cpu_hz_gt,omitempty"`
+	TotalCPUHzGt *int64 `json:"total_cpu_hz_gt,omitempty"`
 
 	// total cpu hz gte
-	TotalCPUHzGte *float64 `json:"total_cpu_hz_gte,omitempty"`
+	TotalCPUHzGte *int64 `json:"total_cpu_hz_gte,omitempty"`
 
 	// total cpu hz in
-	TotalCPUHzIn []float64 `json:"total_cpu_hz_in,omitempty"`
+	TotalCPUHzIn []int64 `json:"total_cpu_hz_in,omitempty"`
 
 	// total cpu hz lt
-	TotalCPUHzLt *float64 `json:"total_cpu_hz_lt,omitempty"`
+	TotalCPUHzLt *int64 `json:"total_cpu_hz_lt,omitempty"`
 
 	// total cpu hz lte
-	TotalCPUHzLte *float64 `json:"total_cpu_hz_lte,omitempty"`
+	TotalCPUHzLte *int64 `json:"total_cpu_hz_lte,omitempty"`
 
 	// total cpu hz not
-	TotalCPUHzNot *float64 `json:"total_cpu_hz_not,omitempty"`
+	TotalCPUHzNot *int64 `json:"total_cpu_hz_not,omitempty"`
 
 	// total cpu hz not in
-	TotalCPUHzNotIn []float64 `json:"total_cpu_hz_not_in,omitempty"`
+	TotalCPUHzNotIn []int64 `json:"total_cpu_hz_not_in,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// total memory bytes gt
-	TotalMemoryBytesGt *float64 `json:"total_memory_bytes_gt,omitempty"`
+	TotalMemoryBytesGt *int64 `json:"total_memory_bytes_gt,omitempty"`
 
 	// total memory bytes gte
-	TotalMemoryBytesGte *float64 `json:"total_memory_bytes_gte,omitempty"`
+	TotalMemoryBytesGte *int64 `json:"total_memory_bytes_gte,omitempty"`
 
 	// total memory bytes in
-	TotalMemoryBytesIn []float64 `json:"total_memory_bytes_in,omitempty"`
+	TotalMemoryBytesIn []int64 `json:"total_memory_bytes_in,omitempty"`
 
 	// total memory bytes lt
-	TotalMemoryBytesLt *float64 `json:"total_memory_bytes_lt,omitempty"`
+	TotalMemoryBytesLt *int64 `json:"total_memory_bytes_lt,omitempty"`
 
 	// total memory bytes lte
-	TotalMemoryBytesLte *float64 `json:"total_memory_bytes_lte,omitempty"`
+	TotalMemoryBytesLte *int64 `json:"total_memory_bytes_lte,omitempty"`
 
 	// total memory bytes not
-	TotalMemoryBytesNot *float64 `json:"total_memory_bytes_not,omitempty"`
+	TotalMemoryBytesNot *int64 `json:"total_memory_bytes_not,omitempty"`
 
 	// total memory bytes not in
-	TotalMemoryBytesNotIn []float64 `json:"total_memory_bytes_not_in,omitempty"`
+	TotalMemoryBytesNotIn []int64 `json:"total_memory_bytes_not_in,omitempty"`
 }
 
 // Validate validates this witness where input

--- a/models/zone.go
+++ b/models/zone.go
@@ -29,7 +29,7 @@ type Zone struct {
 	Datacenter *NestedDatacenter `json:"datacenter"`
 
 	// failure data space
-	FailureDataSpace *float64 `json:"failure_data_space,omitempty"`
+	FailureDataSpace *int64 `json:"failure_data_space,omitempty"`
 
 	// host num
 	HostNum *int32 `json:"host_num,omitempty"`
@@ -55,10 +55,10 @@ type Zone struct {
 	ProvisionedCPUCoresForActiveVM *int32 `json:"provisioned_cpu_cores_for_active_vm,omitempty"`
 
 	// provisioned data space
-	ProvisionedDataSpace *float64 `json:"provisioned_data_space,omitempty"`
+	ProvisionedDataSpace *int64 `json:"provisioned_data_space,omitempty"`
 
 	// provisioned memory bytes
-	ProvisionedMemoryBytes *float64 `json:"provisioned_memory_bytes,omitempty"`
+	ProvisionedMemoryBytes *int64 `json:"provisioned_memory_bytes,omitempty"`
 
 	// running vm num
 	RunningVMNum *int32 `json:"running_vm_num,omitempty"`
@@ -70,25 +70,25 @@ type Zone struct {
 	SuspendedVMNum *int32 `json:"suspended_vm_num,omitempty"`
 
 	// total cache capacity
-	TotalCacheCapacity *float64 `json:"total_cache_capacity,omitempty"`
+	TotalCacheCapacity *int64 `json:"total_cache_capacity,omitempty"`
 
 	// total cpu cores
 	TotalCPUCores *int32 `json:"total_cpu_cores,omitempty"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total data capacity
-	TotalDataCapacity *float64 `json:"total_data_capacity,omitempty"`
+	TotalDataCapacity *int64 `json:"total_data_capacity,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// valid data space
-	ValidDataSpace *float64 `json:"valid_data_space,omitempty"`
+	ValidDataSpace *int64 `json:"valid_data_space,omitempty"`
 
 	// vm num
 	VMNum *int32 `json:"vm_num,omitempty"`

--- a/models/zone_where_input.go
+++ b/models/zone_where_input.go
@@ -36,28 +36,28 @@ type ZoneWhereInput struct {
 	Datacenter *DatacenterWhereInput `json:"datacenter,omitempty"`
 
 	// failure data space
-	FailureDataSpace *float64 `json:"failure_data_space,omitempty"`
+	FailureDataSpace *int64 `json:"failure_data_space,omitempty"`
 
 	// failure data space gt
-	FailureDataSpaceGt *float64 `json:"failure_data_space_gt,omitempty"`
+	FailureDataSpaceGt *int64 `json:"failure_data_space_gt,omitempty"`
 
 	// failure data space gte
-	FailureDataSpaceGte *float64 `json:"failure_data_space_gte,omitempty"`
+	FailureDataSpaceGte *int64 `json:"failure_data_space_gte,omitempty"`
 
 	// failure data space in
-	FailureDataSpaceIn []float64 `json:"failure_data_space_in,omitempty"`
+	FailureDataSpaceIn []int64 `json:"failure_data_space_in,omitempty"`
 
 	// failure data space lt
-	FailureDataSpaceLt *float64 `json:"failure_data_space_lt,omitempty"`
+	FailureDataSpaceLt *int64 `json:"failure_data_space_lt,omitempty"`
 
 	// failure data space lte
-	FailureDataSpaceLte *float64 `json:"failure_data_space_lte,omitempty"`
+	FailureDataSpaceLte *int64 `json:"failure_data_space_lte,omitempty"`
 
 	// failure data space not
-	FailureDataSpaceNot *float64 `json:"failure_data_space_not,omitempty"`
+	FailureDataSpaceNot *int64 `json:"failure_data_space_not,omitempty"`
 
 	// failure data space not in
-	FailureDataSpaceNotIn []float64 `json:"failure_data_space_not_in,omitempty"`
+	FailureDataSpaceNotIn []int64 `json:"failure_data_space_not_in,omitempty"`
 
 	// host num
 	HostNum *int32 `json:"host_num,omitempty"`
@@ -231,52 +231,52 @@ type ZoneWhereInput struct {
 	ProvisionedCPUCoresNotIn []int32 `json:"provisioned_cpu_cores_not_in,omitempty"`
 
 	// provisioned data space
-	ProvisionedDataSpace *float64 `json:"provisioned_data_space,omitempty"`
+	ProvisionedDataSpace *int64 `json:"provisioned_data_space,omitempty"`
 
 	// provisioned data space gt
-	ProvisionedDataSpaceGt *float64 `json:"provisioned_data_space_gt,omitempty"`
+	ProvisionedDataSpaceGt *int64 `json:"provisioned_data_space_gt,omitempty"`
 
 	// provisioned data space gte
-	ProvisionedDataSpaceGte *float64 `json:"provisioned_data_space_gte,omitempty"`
+	ProvisionedDataSpaceGte *int64 `json:"provisioned_data_space_gte,omitempty"`
 
 	// provisioned data space in
-	ProvisionedDataSpaceIn []float64 `json:"provisioned_data_space_in,omitempty"`
+	ProvisionedDataSpaceIn []int64 `json:"provisioned_data_space_in,omitempty"`
 
 	// provisioned data space lt
-	ProvisionedDataSpaceLt *float64 `json:"provisioned_data_space_lt,omitempty"`
+	ProvisionedDataSpaceLt *int64 `json:"provisioned_data_space_lt,omitempty"`
 
 	// provisioned data space lte
-	ProvisionedDataSpaceLte *float64 `json:"provisioned_data_space_lte,omitempty"`
+	ProvisionedDataSpaceLte *int64 `json:"provisioned_data_space_lte,omitempty"`
 
 	// provisioned data space not
-	ProvisionedDataSpaceNot *float64 `json:"provisioned_data_space_not,omitempty"`
+	ProvisionedDataSpaceNot *int64 `json:"provisioned_data_space_not,omitempty"`
 
 	// provisioned data space not in
-	ProvisionedDataSpaceNotIn []float64 `json:"provisioned_data_space_not_in,omitempty"`
+	ProvisionedDataSpaceNotIn []int64 `json:"provisioned_data_space_not_in,omitempty"`
 
 	// provisioned memory bytes
-	ProvisionedMemoryBytes *float64 `json:"provisioned_memory_bytes,omitempty"`
+	ProvisionedMemoryBytes *int64 `json:"provisioned_memory_bytes,omitempty"`
 
 	// provisioned memory bytes gt
-	ProvisionedMemoryBytesGt *float64 `json:"provisioned_memory_bytes_gt,omitempty"`
+	ProvisionedMemoryBytesGt *int64 `json:"provisioned_memory_bytes_gt,omitempty"`
 
 	// provisioned memory bytes gte
-	ProvisionedMemoryBytesGte *float64 `json:"provisioned_memory_bytes_gte,omitempty"`
+	ProvisionedMemoryBytesGte *int64 `json:"provisioned_memory_bytes_gte,omitempty"`
 
 	// provisioned memory bytes in
-	ProvisionedMemoryBytesIn []float64 `json:"provisioned_memory_bytes_in,omitempty"`
+	ProvisionedMemoryBytesIn []int64 `json:"provisioned_memory_bytes_in,omitempty"`
 
 	// provisioned memory bytes lt
-	ProvisionedMemoryBytesLt *float64 `json:"provisioned_memory_bytes_lt,omitempty"`
+	ProvisionedMemoryBytesLt *int64 `json:"provisioned_memory_bytes_lt,omitempty"`
 
 	// provisioned memory bytes lte
-	ProvisionedMemoryBytesLte *float64 `json:"provisioned_memory_bytes_lte,omitempty"`
+	ProvisionedMemoryBytesLte *int64 `json:"provisioned_memory_bytes_lte,omitempty"`
 
 	// provisioned memory bytes not
-	ProvisionedMemoryBytesNot *float64 `json:"provisioned_memory_bytes_not,omitempty"`
+	ProvisionedMemoryBytesNot *int64 `json:"provisioned_memory_bytes_not,omitempty"`
 
 	// provisioned memory bytes not in
-	ProvisionedMemoryBytesNotIn []float64 `json:"provisioned_memory_bytes_not_in,omitempty"`
+	ProvisionedMemoryBytesNotIn []int64 `json:"provisioned_memory_bytes_not_in,omitempty"`
 
 	// running vm num
 	RunningVMNum *int32 `json:"running_vm_num,omitempty"`
@@ -351,28 +351,28 @@ type ZoneWhereInput struct {
 	SuspendedVMNumNotIn []int32 `json:"suspended_vm_num_not_in,omitempty"`
 
 	// total cache capacity
-	TotalCacheCapacity *float64 `json:"total_cache_capacity,omitempty"`
+	TotalCacheCapacity *int64 `json:"total_cache_capacity,omitempty"`
 
 	// total cache capacity gt
-	TotalCacheCapacityGt *float64 `json:"total_cache_capacity_gt,omitempty"`
+	TotalCacheCapacityGt *int64 `json:"total_cache_capacity_gt,omitempty"`
 
 	// total cache capacity gte
-	TotalCacheCapacityGte *float64 `json:"total_cache_capacity_gte,omitempty"`
+	TotalCacheCapacityGte *int64 `json:"total_cache_capacity_gte,omitempty"`
 
 	// total cache capacity in
-	TotalCacheCapacityIn []float64 `json:"total_cache_capacity_in,omitempty"`
+	TotalCacheCapacityIn []int64 `json:"total_cache_capacity_in,omitempty"`
 
 	// total cache capacity lt
-	TotalCacheCapacityLt *float64 `json:"total_cache_capacity_lt,omitempty"`
+	TotalCacheCapacityLt *int64 `json:"total_cache_capacity_lt,omitempty"`
 
 	// total cache capacity lte
-	TotalCacheCapacityLte *float64 `json:"total_cache_capacity_lte,omitempty"`
+	TotalCacheCapacityLte *int64 `json:"total_cache_capacity_lte,omitempty"`
 
 	// total cache capacity not
-	TotalCacheCapacityNot *float64 `json:"total_cache_capacity_not,omitempty"`
+	TotalCacheCapacityNot *int64 `json:"total_cache_capacity_not,omitempty"`
 
 	// total cache capacity not in
-	TotalCacheCapacityNotIn []float64 `json:"total_cache_capacity_not_in,omitempty"`
+	TotalCacheCapacityNotIn []int64 `json:"total_cache_capacity_not_in,omitempty"`
 
 	// total cpu cores
 	TotalCPUCores *int32 `json:"total_cpu_cores,omitempty"`
@@ -399,124 +399,124 @@ type ZoneWhereInput struct {
 	TotalCPUCoresNotIn []int32 `json:"total_cpu_cores_not_in,omitempty"`
 
 	// total cpu hz
-	TotalCPUHz *float64 `json:"total_cpu_hz,omitempty"`
+	TotalCPUHz *int64 `json:"total_cpu_hz,omitempty"`
 
 	// total cpu hz gt
-	TotalCPUHzGt *float64 `json:"total_cpu_hz_gt,omitempty"`
+	TotalCPUHzGt *int64 `json:"total_cpu_hz_gt,omitempty"`
 
 	// total cpu hz gte
-	TotalCPUHzGte *float64 `json:"total_cpu_hz_gte,omitempty"`
+	TotalCPUHzGte *int64 `json:"total_cpu_hz_gte,omitempty"`
 
 	// total cpu hz in
-	TotalCPUHzIn []float64 `json:"total_cpu_hz_in,omitempty"`
+	TotalCPUHzIn []int64 `json:"total_cpu_hz_in,omitempty"`
 
 	// total cpu hz lt
-	TotalCPUHzLt *float64 `json:"total_cpu_hz_lt,omitempty"`
+	TotalCPUHzLt *int64 `json:"total_cpu_hz_lt,omitempty"`
 
 	// total cpu hz lte
-	TotalCPUHzLte *float64 `json:"total_cpu_hz_lte,omitempty"`
+	TotalCPUHzLte *int64 `json:"total_cpu_hz_lte,omitempty"`
 
 	// total cpu hz not
-	TotalCPUHzNot *float64 `json:"total_cpu_hz_not,omitempty"`
+	TotalCPUHzNot *int64 `json:"total_cpu_hz_not,omitempty"`
 
 	// total cpu hz not in
-	TotalCPUHzNotIn []float64 `json:"total_cpu_hz_not_in,omitempty"`
+	TotalCPUHzNotIn []int64 `json:"total_cpu_hz_not_in,omitempty"`
 
 	// total data capacity
-	TotalDataCapacity *float64 `json:"total_data_capacity,omitempty"`
+	TotalDataCapacity *int64 `json:"total_data_capacity,omitempty"`
 
 	// total data capacity gt
-	TotalDataCapacityGt *float64 `json:"total_data_capacity_gt,omitempty"`
+	TotalDataCapacityGt *int64 `json:"total_data_capacity_gt,omitempty"`
 
 	// total data capacity gte
-	TotalDataCapacityGte *float64 `json:"total_data_capacity_gte,omitempty"`
+	TotalDataCapacityGte *int64 `json:"total_data_capacity_gte,omitempty"`
 
 	// total data capacity in
-	TotalDataCapacityIn []float64 `json:"total_data_capacity_in,omitempty"`
+	TotalDataCapacityIn []int64 `json:"total_data_capacity_in,omitempty"`
 
 	// total data capacity lt
-	TotalDataCapacityLt *float64 `json:"total_data_capacity_lt,omitempty"`
+	TotalDataCapacityLt *int64 `json:"total_data_capacity_lt,omitempty"`
 
 	// total data capacity lte
-	TotalDataCapacityLte *float64 `json:"total_data_capacity_lte,omitempty"`
+	TotalDataCapacityLte *int64 `json:"total_data_capacity_lte,omitempty"`
 
 	// total data capacity not
-	TotalDataCapacityNot *float64 `json:"total_data_capacity_not,omitempty"`
+	TotalDataCapacityNot *int64 `json:"total_data_capacity_not,omitempty"`
 
 	// total data capacity not in
-	TotalDataCapacityNotIn []float64 `json:"total_data_capacity_not_in,omitempty"`
+	TotalDataCapacityNotIn []int64 `json:"total_data_capacity_not_in,omitempty"`
 
 	// total memory bytes
-	TotalMemoryBytes *float64 `json:"total_memory_bytes,omitempty"`
+	TotalMemoryBytes *int64 `json:"total_memory_bytes,omitempty"`
 
 	// total memory bytes gt
-	TotalMemoryBytesGt *float64 `json:"total_memory_bytes_gt,omitempty"`
+	TotalMemoryBytesGt *int64 `json:"total_memory_bytes_gt,omitempty"`
 
 	// total memory bytes gte
-	TotalMemoryBytesGte *float64 `json:"total_memory_bytes_gte,omitempty"`
+	TotalMemoryBytesGte *int64 `json:"total_memory_bytes_gte,omitempty"`
 
 	// total memory bytes in
-	TotalMemoryBytesIn []float64 `json:"total_memory_bytes_in,omitempty"`
+	TotalMemoryBytesIn []int64 `json:"total_memory_bytes_in,omitempty"`
 
 	// total memory bytes lt
-	TotalMemoryBytesLt *float64 `json:"total_memory_bytes_lt,omitempty"`
+	TotalMemoryBytesLt *int64 `json:"total_memory_bytes_lt,omitempty"`
 
 	// total memory bytes lte
-	TotalMemoryBytesLte *float64 `json:"total_memory_bytes_lte,omitempty"`
+	TotalMemoryBytesLte *int64 `json:"total_memory_bytes_lte,omitempty"`
 
 	// total memory bytes not
-	TotalMemoryBytesNot *float64 `json:"total_memory_bytes_not,omitempty"`
+	TotalMemoryBytesNot *int64 `json:"total_memory_bytes_not,omitempty"`
 
 	// total memory bytes not in
-	TotalMemoryBytesNotIn []float64 `json:"total_memory_bytes_not_in,omitempty"`
+	TotalMemoryBytesNotIn []int64 `json:"total_memory_bytes_not_in,omitempty"`
 
 	// used data space
-	UsedDataSpace *float64 `json:"used_data_space,omitempty"`
+	UsedDataSpace *int64 `json:"used_data_space,omitempty"`
 
 	// used data space gt
-	UsedDataSpaceGt *float64 `json:"used_data_space_gt,omitempty"`
+	UsedDataSpaceGt *int64 `json:"used_data_space_gt,omitempty"`
 
 	// used data space gte
-	UsedDataSpaceGte *float64 `json:"used_data_space_gte,omitempty"`
+	UsedDataSpaceGte *int64 `json:"used_data_space_gte,omitempty"`
 
 	// used data space in
-	UsedDataSpaceIn []float64 `json:"used_data_space_in,omitempty"`
+	UsedDataSpaceIn []int64 `json:"used_data_space_in,omitempty"`
 
 	// used data space lt
-	UsedDataSpaceLt *float64 `json:"used_data_space_lt,omitempty"`
+	UsedDataSpaceLt *int64 `json:"used_data_space_lt,omitempty"`
 
 	// used data space lte
-	UsedDataSpaceLte *float64 `json:"used_data_space_lte,omitempty"`
+	UsedDataSpaceLte *int64 `json:"used_data_space_lte,omitempty"`
 
 	// used data space not
-	UsedDataSpaceNot *float64 `json:"used_data_space_not,omitempty"`
+	UsedDataSpaceNot *int64 `json:"used_data_space_not,omitempty"`
 
 	// used data space not in
-	UsedDataSpaceNotIn []float64 `json:"used_data_space_not_in,omitempty"`
+	UsedDataSpaceNotIn []int64 `json:"used_data_space_not_in,omitempty"`
 
 	// valid data space
-	ValidDataSpace *float64 `json:"valid_data_space,omitempty"`
+	ValidDataSpace *int64 `json:"valid_data_space,omitempty"`
 
 	// valid data space gt
-	ValidDataSpaceGt *float64 `json:"valid_data_space_gt,omitempty"`
+	ValidDataSpaceGt *int64 `json:"valid_data_space_gt,omitempty"`
 
 	// valid data space gte
-	ValidDataSpaceGte *float64 `json:"valid_data_space_gte,omitempty"`
+	ValidDataSpaceGte *int64 `json:"valid_data_space_gte,omitempty"`
 
 	// valid data space in
-	ValidDataSpaceIn []float64 `json:"valid_data_space_in,omitempty"`
+	ValidDataSpaceIn []int64 `json:"valid_data_space_in,omitempty"`
 
 	// valid data space lt
-	ValidDataSpaceLt *float64 `json:"valid_data_space_lt,omitempty"`
+	ValidDataSpaceLt *int64 `json:"valid_data_space_lt,omitempty"`
 
 	// valid data space lte
-	ValidDataSpaceLte *float64 `json:"valid_data_space_lte,omitempty"`
+	ValidDataSpaceLte *int64 `json:"valid_data_space_lte,omitempty"`
 
 	// valid data space not
-	ValidDataSpaceNot *float64 `json:"valid_data_space_not,omitempty"`
+	ValidDataSpaceNot *int64 `json:"valid_data_space_not,omitempty"`
 
 	// valid data space not in
-	ValidDataSpaceNotIn []float64 `json:"valid_data_space_not_in,omitempty"`
+	ValidDataSpaceNotIn []int64 `json:"valid_data_space_not_in,omitempty"`
 
 	// vm num
 	VMNum *int32 `json:"vm_num,omitempty"`


### PR DESCRIPTION
As limit of prisma1 dsl, we use float for big decimal.
For sdk, number type should overwrite by its correct number type.