### PR TITLE
bugfix: update UniqueLogicalSize from int64 to float64

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,5 +1,13 @@
 # RELEASE NOTE
 
+## release 日期 2024-05-30
+
+v2.15.1 release (tower version 4.1.0)
+
+### bugfix
+
+- [VM], [VMVolume], [IscsiLun], [NvmfNameSpace], [NfsInode]: 更新 `UniqueLogicalSize` 类型为 `float64`
+
 ## release 日期 2024-05-11
 
 v2.15.0 release (tower version 4.1.0)

--- a/models/iscsi_lun.go
+++ b/models/iscsi_lun.go
@@ -162,7 +162,7 @@ type IscsiLun struct {
 	ThinProvision *bool `json:"thin_provision"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique size
 	// Required: true

--- a/models/iscsi_lun_where_input.go
+++ b/models/iscsi_lun_where_input.go
@@ -878,28 +878,28 @@ type IscsiLunWhereInput struct {
 	ThinProvisionNot *bool `json:"thin_provision_not,omitempty"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique logical size gt
-	UniqueLogicalSizeGt *int64 `json:"unique_logical_size_gt,omitempty"`
+	UniqueLogicalSizeGt *float64 `json:"unique_logical_size_gt,omitempty"`
 
 	// unique logical size gte
-	UniqueLogicalSizeGte *int64 `json:"unique_logical_size_gte,omitempty"`
+	UniqueLogicalSizeGte *float64 `json:"unique_logical_size_gte,omitempty"`
 
 	// unique logical size in
-	UniqueLogicalSizeIn []int64 `json:"unique_logical_size_in,omitempty"`
+	UniqueLogicalSizeIn []float64 `json:"unique_logical_size_in,omitempty"`
 
 	// unique logical size lt
-	UniqueLogicalSizeLt *int64 `json:"unique_logical_size_lt,omitempty"`
+	UniqueLogicalSizeLt *float64 `json:"unique_logical_size_lt,omitempty"`
 
 	// unique logical size lte
-	UniqueLogicalSizeLte *int64 `json:"unique_logical_size_lte,omitempty"`
+	UniqueLogicalSizeLte *float64 `json:"unique_logical_size_lte,omitempty"`
 
 	// unique logical size not
-	UniqueLogicalSizeNot *int64 `json:"unique_logical_size_not,omitempty"`
+	UniqueLogicalSizeNot *float64 `json:"unique_logical_size_not,omitempty"`
 
 	// unique logical size not in
-	UniqueLogicalSizeNotIn []int64 `json:"unique_logical_size_not_in,omitempty"`
+	UniqueLogicalSizeNotIn []float64 `json:"unique_logical_size_not_in,omitempty"`
 
 	// unique size
 	UniqueSize *int64 `json:"unique_size,omitempty"`

--- a/models/nfs_inode.go
+++ b/models/nfs_inode.go
@@ -67,7 +67,7 @@ type NfsInode struct {
 	SnapshotNum *int32 `json:"snapshot_num"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique size
 	// Required: true

--- a/models/nfs_inode_where_input.go
+++ b/models/nfs_inode_where_input.go
@@ -323,28 +323,28 @@ type NfsInodeWhereInput struct {
 	SnapshotNumNotIn []int32 `json:"snapshot_num_not_in,omitempty"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique logical size gt
-	UniqueLogicalSizeGt *int64 `json:"unique_logical_size_gt,omitempty"`
+	UniqueLogicalSizeGt *float64 `json:"unique_logical_size_gt,omitempty"`
 
 	// unique logical size gte
-	UniqueLogicalSizeGte *int64 `json:"unique_logical_size_gte,omitempty"`
+	UniqueLogicalSizeGte *float64 `json:"unique_logical_size_gte,omitempty"`
 
 	// unique logical size in
-	UniqueLogicalSizeIn []int64 `json:"unique_logical_size_in,omitempty"`
+	UniqueLogicalSizeIn []float64 `json:"unique_logical_size_in,omitempty"`
 
 	// unique logical size lt
-	UniqueLogicalSizeLt *int64 `json:"unique_logical_size_lt,omitempty"`
+	UniqueLogicalSizeLt *float64 `json:"unique_logical_size_lt,omitempty"`
 
 	// unique logical size lte
-	UniqueLogicalSizeLte *int64 `json:"unique_logical_size_lte,omitempty"`
+	UniqueLogicalSizeLte *float64 `json:"unique_logical_size_lte,omitempty"`
 
 	// unique logical size not
-	UniqueLogicalSizeNot *int64 `json:"unique_logical_size_not,omitempty"`
+	UniqueLogicalSizeNot *float64 `json:"unique_logical_size_not,omitempty"`
 
 	// unique logical size not in
-	UniqueLogicalSizeNotIn []int64 `json:"unique_logical_size_not_in,omitempty"`
+	UniqueLogicalSizeNotIn []float64 `json:"unique_logical_size_not_in,omitempty"`
 
 	// unique size
 	UniqueSize *int64 `json:"unique_size,omitempty"`

--- a/models/nvmf_namespace.go
+++ b/models/nvmf_namespace.go
@@ -169,7 +169,7 @@ type NvmfNamespace struct {
 	ThinProvision *bool `json:"thin_provision"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique size
 	// Required: true

--- a/models/nvmf_namespace_where_input.go
+++ b/models/nvmf_namespace_where_input.go
@@ -887,28 +887,28 @@ type NvmfNamespaceWhereInput struct {
 	ThinProvisionNot *bool `json:"thin_provision_not,omitempty"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique logical size gt
-	UniqueLogicalSizeGt *int64 `json:"unique_logical_size_gt,omitempty"`
+	UniqueLogicalSizeGt *float64 `json:"unique_logical_size_gt,omitempty"`
 
 	// unique logical size gte
-	UniqueLogicalSizeGte *int64 `json:"unique_logical_size_gte,omitempty"`
+	UniqueLogicalSizeGte *float64 `json:"unique_logical_size_gte,omitempty"`
 
 	// unique logical size in
-	UniqueLogicalSizeIn []int64 `json:"unique_logical_size_in,omitempty"`
+	UniqueLogicalSizeIn []float64 `json:"unique_logical_size_in,omitempty"`
 
 	// unique logical size lt
-	UniqueLogicalSizeLt *int64 `json:"unique_logical_size_lt,omitempty"`
+	UniqueLogicalSizeLt *float64 `json:"unique_logical_size_lt,omitempty"`
 
 	// unique logical size lte
-	UniqueLogicalSizeLte *int64 `json:"unique_logical_size_lte,omitempty"`
+	UniqueLogicalSizeLte *float64 `json:"unique_logical_size_lte,omitempty"`
 
 	// unique logical size not
-	UniqueLogicalSizeNot *int64 `json:"unique_logical_size_not,omitempty"`
+	UniqueLogicalSizeNot *float64 `json:"unique_logical_size_not,omitempty"`
 
 	// unique logical size not in
-	UniqueLogicalSizeNotIn []int64 `json:"unique_logical_size_not_in,omitempty"`
+	UniqueLogicalSizeNotIn []float64 `json:"unique_logical_size_not_in,omitempty"`
 
 	// unique size
 	UniqueSize *int64 `json:"unique_size,omitempty"`

--- a/models/vm.go
+++ b/models/vm.go
@@ -195,7 +195,7 @@ type VM struct {
 	Status *VMStatus `json:"status"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique size
 	UniqueSize *int64 `json:"unique_size,omitempty"`

--- a/models/vm_volume.go
+++ b/models/vm_volume.go
@@ -82,7 +82,7 @@ type VMVolume struct {
 	Type *VMVolumeType `json:"type,omitempty"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique size
 	UniqueSize *int64 `json:"unique_size,omitempty"`

--- a/models/vm_volume_where_input.go
+++ b/models/vm_volume_where_input.go
@@ -398,28 +398,28 @@ type VMVolumeWhereInput struct {
 	TypeNotIn []VMVolumeType `json:"type_not_in,omitempty"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique logical size gt
-	UniqueLogicalSizeGt *int64 `json:"unique_logical_size_gt,omitempty"`
+	UniqueLogicalSizeGt *float64 `json:"unique_logical_size_gt,omitempty"`
 
 	// unique logical size gte
-	UniqueLogicalSizeGte *int64 `json:"unique_logical_size_gte,omitempty"`
+	UniqueLogicalSizeGte *float64 `json:"unique_logical_size_gte,omitempty"`
 
 	// unique logical size in
-	UniqueLogicalSizeIn []int64 `json:"unique_logical_size_in,omitempty"`
+	UniqueLogicalSizeIn []float64 `json:"unique_logical_size_in,omitempty"`
 
 	// unique logical size lt
-	UniqueLogicalSizeLt *int64 `json:"unique_logical_size_lt,omitempty"`
+	UniqueLogicalSizeLt *float64 `json:"unique_logical_size_lt,omitempty"`
 
 	// unique logical size lte
-	UniqueLogicalSizeLte *int64 `json:"unique_logical_size_lte,omitempty"`
+	UniqueLogicalSizeLte *float64 `json:"unique_logical_size_lte,omitempty"`
 
 	// unique logical size not
-	UniqueLogicalSizeNot *int64 `json:"unique_logical_size_not,omitempty"`
+	UniqueLogicalSizeNot *float64 `json:"unique_logical_size_not,omitempty"`
 
 	// unique logical size not in
-	UniqueLogicalSizeNotIn []int64 `json:"unique_logical_size_not_in,omitempty"`
+	UniqueLogicalSizeNotIn []float64 `json:"unique_logical_size_not_in,omitempty"`
 
 	// unique size
 	UniqueSize *int64 `json:"unique_size,omitempty"`

--- a/models/vm_where_input.go
+++ b/models/vm_where_input.go
@@ -1079,28 +1079,28 @@ type VMWhereInput struct {
 	StatusNotIn []VMStatus `json:"status_not_in,omitempty"`
 
 	// unique logical size
-	UniqueLogicalSize *int64 `json:"unique_logical_size,omitempty"`
+	UniqueLogicalSize *float64 `json:"unique_logical_size,omitempty"`
 
 	// unique logical size gt
-	UniqueLogicalSizeGt *int64 `json:"unique_logical_size_gt,omitempty"`
+	UniqueLogicalSizeGt *float64 `json:"unique_logical_size_gt,omitempty"`
 
 	// unique logical size gte
-	UniqueLogicalSizeGte *int64 `json:"unique_logical_size_gte,omitempty"`
+	UniqueLogicalSizeGte *float64 `json:"unique_logical_size_gte,omitempty"`
 
 	// unique logical size in
-	UniqueLogicalSizeIn []int64 `json:"unique_logical_size_in,omitempty"`
+	UniqueLogicalSizeIn []float64 `json:"unique_logical_size_in,omitempty"`
 
 	// unique logical size lt
-	UniqueLogicalSizeLt *int64 `json:"unique_logical_size_lt,omitempty"`
+	UniqueLogicalSizeLt *float64 `json:"unique_logical_size_lt,omitempty"`
 
 	// unique logical size lte
-	UniqueLogicalSizeLte *int64 `json:"unique_logical_size_lte,omitempty"`
+	UniqueLogicalSizeLte *float64 `json:"unique_logical_size_lte,omitempty"`
 
 	// unique logical size not
-	UniqueLogicalSizeNot *int64 `json:"unique_logical_size_not,omitempty"`
+	UniqueLogicalSizeNot *float64 `json:"unique_logical_size_not,omitempty"`
 
 	// unique logical size not in
-	UniqueLogicalSizeNotIn []int64 `json:"unique_logical_size_not_in,omitempty"`
+	UniqueLogicalSizeNotIn []float64 `json:"unique_logical_size_not_in,omitempty"`
 
 	// unique size
 	UniqueSize *int64 `json:"unique_size,omitempty"`


### PR DESCRIPTION
## release 日期 2024-05-30

v2.15.1 release (tower version 4.1.0)

### bugfix

- [VM], [VMVolume], [IscsiLun], [NvmfNameSpace], [NfsInode]: 更新 `UniqueLogicalSize` 类型为 `float64`