### PR TITLE
bugfix: fix crc watchor current revision

### DIFF
--- a/watchor/resource_change_event.go
+++ b/watchor/resource_change_event.go
@@ -294,7 +294,6 @@ func (c *ResourceChangeWatchClient) pollOnce() error {
 		if !c.started.Load() {
 			return nil
 		}
-
 		c.currentRevision = event.Revision
 		c.writeToChannel(event)
 	}


### PR DESCRIPTION
fix catchup and current revision update:
1. when not catch up, use latest event's revision as current revision, start next poll from the current revision
2. when no event will fetched up, treat event caught up, use current revision from payload to update current revision(previously, we use current revision from payload to compare with current revision in struct, may cause data never catch up if only listen to few resource)
3. when caught up, always use current revision from payload