### PR TITLE
poc: add active-passive failover client

### DIFF
--- a/client/active_passive_client.go
+++ b/client/active_passive_client.go
@@ -80,10 +80,11 @@ type ActivePassiveClient struct {
 }
 
 type activePassiveEndpoint struct {
-	host        string
-	runtime     *httptransport.Runtime
-	httpClient  *http.Client
-	probeClient *Cloudtower
+	host         string
+	runtime      *httptransport.Runtime
+	httpClient   *http.Client
+	probeRuntime *httptransport.Runtime
+	probeClient  *http.Client
 }
 
 type activePassiveSubmitState int
@@ -216,13 +217,13 @@ func newActivePassiveTransport(clientConfig ActivePassiveClientConfig, formats s
 		runtime.Formats = formats
 		probeRuntime := httptransport.NewWithClient(host, "/", cfg.Schemes, httpClient)
 		probeRuntime.Formats = formats
-		probeClient := New(probeRuntime, formats)
 
 		transport.endpoints[host] = &activePassiveEndpoint{
-			host:        host,
-			runtime:     runtime,
-			httpClient:  httpClient,
-			probeClient: probeClient,
+			host:         host,
+			runtime:      runtime,
+			httpClient:   httpClient,
+			probeRuntime: probeRuntime,
+			probeClient:  httpClient,
 		}
 		transport.orderedHosts = append(transport.orderedHosts, host)
 	}
@@ -412,15 +413,41 @@ func (t *ActivePassiveTransport) probeHost(ctx context.Context, host string) (ac
 	reqCtx, cancel := context.WithTimeout(defaultContext(ctx), t.probeTimeout)
 	defer cancel()
 
-	isActive, err := endpoint.probeClient.ProbeActivePassive(reqCtx)
+	req, err := endpoint.probeRuntime.CreateHttpRequest(activePassiveProbeOperation(reqCtx))
 	if err != nil {
 		return 0, err
 	}
-	if isActive {
-		return activePassiveProbeActive, nil
-	}
 
-	return activePassiveProbePassive, nil
+	resp, err := endpoint.probeClient.Do(req.WithContext(reqCtx))
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return activePassiveProbeActive, nil
+	case http.StatusTemporaryRedirect:
+		return activePassiveProbePassive, nil
+	default:
+		return 0, goruntime.NewAPIError("probe active-passive returned unexpected status", activePassiveHTTPResponse{response: resp}, resp.StatusCode)
+	}
+}
+
+func activePassiveProbeOperation(ctx context.Context) *goruntime.ClientOperation {
+	return &goruntime.ClientOperation{
+		ID:                 "probe-active-passive",
+		Method:             http.MethodGet,
+		PathPattern:        "/api/healthz",
+		ProducesMediaTypes: []string{goruntime.JSONMime},
+		Params: goruntime.ClientRequestWriterFunc(func(goruntime.ClientRequest, strfmt.Registry) error {
+			return nil
+		}),
+		Reader: goruntime.ClientResponseReaderFunc(func(goruntime.ClientResponse, goruntime.Consumer) (interface{}, error) {
+			return nil, nil
+		}),
+		Context: ctx,
+	}
 }
 
 func (t *ActivePassiveTransport) submitToHost(host string, op *goruntime.ClientOperation) activePassiveSubmitResult {

--- a/client/active_passive_client.go
+++ b/client/active_passive_client.go
@@ -1,0 +1,634 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	goruntime "github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
+)
+
+var (
+	ErrActivePassiveNoEndpoints      = errors.New("active-passive client requires at least one endpoint")
+	ErrActivePassiveDuplicateHost    = errors.New("active-passive client endpoints must be unique")
+	ErrActivePassiveNoActiveHost     = errors.New("active-passive discover found no active host")
+	ErrActivePassiveMultipleActives  = errors.New("active-passive discover found multiple active hosts")
+	ErrActivePassiveRetryExhausted   = errors.New("active-passive request retry exhausted after discover")
+	ErrActivePassiveMissingLocation  = errors.New("active-passive redirect is missing location header")
+	ErrActivePassiveFailoverRequired = errors.New("active-passive failover required")
+	ErrActivePassiveUnknownHost      = errors.New("active-passive current active host is not configured")
+	ErrActivePassiveUnsupportedAuth  = errors.New("client transport does not support default authentication")
+	errActivePassiveNoResponseReader = errors.New("client operation does not provide a response reader")
+)
+
+// FailoverStrategy controls when active-passive client discovers and retries endpoints.
+type FailoverStrategy int
+
+const (
+	FailoverStrategyDefault FailoverStrategy = iota
+	FailoverStrategyManualFailover
+	FailoverStrategyAlwaysProbe
+)
+
+// ActivePassiveClientConfig contains transport-related options for the active-passive client.
+type ActivePassiveClientConfig struct {
+	Endpoints        []string
+	BasePath         string
+	Schemes          []string
+	UserConfig       *UserConfig
+	ProbeTimeout     time.Duration
+	HTTPClient       *http.Client
+	FailoverStrategy FailoverStrategy
+	formats          *strfmt.Registry
+}
+
+// DefaultActivePassiveClientConfig returns the default config for an active-passive client.
+func DefaultActivePassiveClientConfig() *ActivePassiveClientConfig {
+	return &ActivePassiveClientConfig{
+		BasePath:     DefaultBasePath,
+		Schemes:      DefaultSchemes,
+		ProbeTimeout: httptransport.DefaultTimeout,
+	}
+}
+
+// ActivePassiveTransport routes requests to the current active endpoint.
+type ActivePassiveTransport struct {
+	mu                sync.RWMutex
+	endpoints         map[string]*activePassiveEndpoint
+	orderedHosts      []string
+	currentActiveHost string
+	discoverWait      chan struct{}
+	discoverErr       error
+	probeTimeout      time.Duration
+	failoverStrategy  FailoverStrategy
+}
+
+// ActivePassiveClient wraps Cloudtower with active-passive specific state accessors.
+type ActivePassiveClient struct {
+	*Cloudtower
+	transport *ActivePassiveTransport
+}
+
+type activePassiveEndpoint struct {
+	host        string
+	runtime     *httptransport.Runtime
+	httpClient  *http.Client
+	probeClient *Cloudtower
+}
+
+type activePassiveSubmitState int
+
+const (
+	activePassiveSubmitSuccess activePassiveSubmitState = iota
+	activePassiveSubmitRecognizableError
+	activePassiveSubmitUnrecognizableError
+	activePassiveSubmitSwitchSignal
+	activePassiveSubmitLocalError
+)
+
+type activePassiveSubmitResult struct {
+	state  activePassiveSubmitState
+	result interface{}
+	err    error
+}
+
+type activePassiveProbeState int
+
+const (
+	activePassiveProbeActive activePassiveProbeState = iota
+	activePassiveProbePassive
+)
+
+type activePassiveHTTPResponse struct {
+	response *http.Response
+}
+
+func (r activePassiveHTTPResponse) Code() int {
+	return r.response.StatusCode
+}
+
+func (r activePassiveHTTPResponse) Message() string {
+	return r.response.Status
+}
+
+func (r activePassiveHTTPResponse) GetHeader(name string) string {
+	return r.response.Header.Get(name)
+}
+
+func (r activePassiveHTTPResponse) GetHeaders(name string) []string {
+	return r.response.Header.Values(name)
+}
+
+func (r activePassiveHTTPResponse) Body() io.ReadCloser {
+	return r.response.Body
+}
+
+// NewActivePassiveClient creates a new active-passive cloudtower client.
+func NewActivePassiveClient(ctx context.Context, clientConfig ActivePassiveClientConfig) (*ActivePassiveClient, error) {
+	if ctx == nil {
+		timeout := clientConfig.ProbeTimeout
+		if timeout == 0 {
+			timeout = httptransport.DefaultTimeout
+		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+	}
+
+	formats := strfmt.Default
+	if clientConfig.formats != nil {
+		formats = *clientConfig.formats
+	}
+
+	transport, err := newActivePassiveTransport(clientConfig, formats)
+	if err != nil {
+		return nil, err
+	}
+
+	cloudtowerClient := New(transport, formats)
+	client := &ActivePassiveClient{
+		Cloudtower: cloudtowerClient,
+		transport:  transport,
+	}
+	if clientConfig.UserConfig != nil {
+		host, err := transport.ensureActiveHost(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := loginWithUserConfig(client.Cloudtower, host, *clientConfig.UserConfig); err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}
+
+// NewActivePassiveWithUserConfig creates a new active-passive client and logs in.
+func NewActivePassiveWithUserConfig(ctx context.Context, clientConfig ActivePassiveClientConfig, userConfig UserConfig) (*ActivePassiveClient, error) {
+	clientConfig.UserConfig = &userConfig
+	return NewActivePassiveClient(ctx, clientConfig)
+}
+
+func newActivePassiveTransport(clientConfig ActivePassiveClientConfig, formats strfmt.Registry) (*ActivePassiveTransport, error) {
+	cfg := clientConfig
+	if cfg.BasePath == "" {
+		cfg.BasePath = DefaultBasePath
+	}
+	if len(cfg.Schemes) == 0 {
+		cfg.Schemes = DefaultSchemes
+	}
+	if cfg.ProbeTimeout == 0 {
+		cfg.ProbeTimeout = httptransport.DefaultTimeout
+	}
+	if len(cfg.Endpoints) == 0 {
+		return nil, ErrActivePassiveNoEndpoints
+	}
+
+	transport := &ActivePassiveTransport{
+		endpoints:        make(map[string]*activePassiveEndpoint, len(cfg.Endpoints)),
+		orderedHosts:     make([]string, 0, len(cfg.Endpoints)),
+		probeTimeout:     cfg.ProbeTimeout,
+		failoverStrategy: cfg.FailoverStrategy,
+	}
+
+	for _, endpoint := range cfg.Endpoints {
+		host := strings.TrimSpace(endpoint)
+		if host == "" {
+			return nil, ErrActivePassiveNoEndpoints
+		}
+		if _, exists := transport.endpoints[host]; exists {
+			return nil, fmt.Errorf("%w: %s", ErrActivePassiveDuplicateHost, host)
+		}
+
+		httpClient := cloneNoRedirectHTTPClient(cfg.HTTPClient)
+		runtime := httptransport.NewWithClient(host, cfg.BasePath, cfg.Schemes, httpClient)
+		runtime.Formats = formats
+		probeRuntime := httptransport.NewWithClient(host, "/", cfg.Schemes, httpClient)
+		probeRuntime.Formats = formats
+		probeClient := New(probeRuntime, formats)
+
+		transport.endpoints[host] = &activePassiveEndpoint{
+			host:        host,
+			runtime:     runtime,
+			httpClient:  httpClient,
+			probeClient: probeClient,
+		}
+		transport.orderedHosts = append(transport.orderedHosts, host)
+	}
+
+	return transport, nil
+}
+
+// Submit routes the client operation to the current active host.
+func (t *ActivePassiveTransport) Submit(op *goruntime.ClientOperation) (interface{}, error) {
+	host, err := t.hostForRequest(op.Context)
+	if err != nil {
+		return nil, err
+	}
+
+	result := t.submitToHost(host, op)
+	switch result.state {
+	case activePassiveSubmitSuccess:
+		return result.result, nil
+	case activePassiveSubmitRecognizableError, activePassiveSubmitLocalError:
+		return nil, result.err
+	case activePassiveSubmitUnrecognizableError:
+		t.clearCurrentActiveHostIf(host)
+		return nil, result.err
+	case activePassiveSubmitSwitchSignal:
+		t.clearCurrentActiveHostIf(host)
+		if t.failoverStrategy == FailoverStrategyManualFailover || t.failoverStrategy == FailoverStrategyAlwaysProbe {
+			return nil, fmt.Errorf("%w: %v", ErrActivePassiveFailoverRequired, result.err)
+		}
+
+		nextHost, err := t.ensureActiveHost(op.Context)
+		if err != nil {
+			return nil, err
+		}
+
+		retry := t.submitToHost(nextHost, op)
+		switch retry.state {
+		case activePassiveSubmitSuccess:
+			return retry.result, nil
+		case activePassiveSubmitRecognizableError, activePassiveSubmitLocalError:
+			return nil, retry.err
+		case activePassiveSubmitUnrecognizableError:
+			t.clearCurrentActiveHostIf(nextHost)
+			return nil, retry.err
+		case activePassiveSubmitSwitchSignal:
+			t.clearCurrentActiveHostIf(nextHost)
+			return nil, ErrActivePassiveRetryExhausted
+		default:
+			return nil, retry.err
+		}
+	default:
+		return nil, result.err
+	}
+}
+
+func (t *ActivePassiveTransport) hostForRequest(ctx context.Context) (string, error) {
+	if t.failoverStrategy == FailoverStrategyAlwaysProbe {
+		t.clearCurrentActiveHost()
+	}
+
+	return t.ensureActiveHost(ctx)
+}
+
+// SetDefaultAuthentication updates the auth info writer on every endpoint runtime.
+func (t *ActivePassiveTransport) SetDefaultAuthentication(auth goruntime.ClientAuthInfoWriter) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, endpoint := range t.endpoints {
+		endpoint.runtime.DefaultAuthentication = auth
+	}
+}
+
+// CurrentActiveHost returns the host currently used for request routing.
+func (t *ActivePassiveTransport) CurrentActiveHost() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.currentActiveHost
+}
+
+// SetDefaultAuthentication updates the authentication writer for both regular and active-passive clients.
+func (c *Cloudtower) SetDefaultAuthentication(auth goruntime.ClientAuthInfoWriter) {
+	switch transport := c.Transport.(type) {
+	case *ActivePassiveTransport:
+		transport.SetDefaultAuthentication(auth)
+	case *httptransport.Runtime:
+		transport.DefaultAuthentication = auth
+	}
+}
+
+// CurrentActiveHost returns the last discovered active host.
+func (c *ActivePassiveClient) CurrentActiveHost() string {
+	if c == nil || c.transport == nil {
+		return ""
+	}
+	return c.transport.CurrentActiveHost()
+}
+
+func (t *ActivePassiveTransport) ensureActiveHost(ctx context.Context) (string, error) {
+	if host := t.CurrentActiveHost(); host != "" {
+		return host, nil
+	}
+
+	for {
+		t.mu.Lock()
+		if t.currentActiveHost != "" {
+			host := t.currentActiveHost
+			t.mu.Unlock()
+			return host, nil
+		}
+
+		if wait := t.discoverWait; wait != nil {
+			t.mu.Unlock()
+			if err := waitForDiscover(ctx, wait); err != nil {
+				return "", err
+			}
+
+			t.mu.RLock()
+			host := t.currentActiveHost
+			err := t.discoverErr
+			t.mu.RUnlock()
+			if host != "" {
+				return host, nil
+			}
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+
+		wait := make(chan struct{})
+		t.discoverWait = wait
+		t.mu.Unlock()
+
+		host, err := t.discover(ctx)
+
+		t.mu.Lock()
+		if err == nil {
+			t.currentActiveHost = host
+		}
+		t.discoverErr = err
+		close(wait)
+		t.discoverWait = nil
+		host = t.currentActiveHost
+		t.mu.Unlock()
+
+		if err != nil {
+			return "", err
+		}
+		return host, nil
+	}
+}
+
+func (t *ActivePassiveTransport) discover(ctx context.Context) (string, error) {
+	activeHosts := make([]string, 0, 1)
+	failures := make([]string, 0)
+
+	for _, host := range t.orderedHosts {
+		state, err := t.probeHost(ctx, host)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", host, err))
+			continue
+		}
+		if state == activePassiveProbeActive {
+			activeHosts = append(activeHosts, host)
+		}
+	}
+
+	switch len(activeHosts) {
+	case 1:
+		return activeHosts[0], nil
+	case 0:
+		if len(failures) == 0 {
+			return "", ErrActivePassiveNoActiveHost
+		}
+		return "", fmt.Errorf("%w: %s", ErrActivePassiveNoActiveHost, strings.Join(failures, "; "))
+	default:
+		return "", fmt.Errorf("%w: %s", ErrActivePassiveMultipleActives, strings.Join(activeHosts, ", "))
+	}
+}
+
+func (t *ActivePassiveTransport) probeHost(ctx context.Context, host string) (activePassiveProbeState, error) {
+	endpoint, ok := t.endpoints[host]
+	if !ok {
+		return 0, fmt.Errorf("%w: %s", ErrActivePassiveUnknownHost, host)
+	}
+
+	reqCtx, cancel := context.WithTimeout(defaultContext(ctx), t.probeTimeout)
+	defer cancel()
+
+	isActive, err := endpoint.probeClient.ProbeActivePassive(reqCtx)
+	if err != nil {
+		return 0, err
+	}
+	if isActive {
+		return activePassiveProbeActive, nil
+	}
+
+	return activePassiveProbePassive, nil
+}
+
+func (t *ActivePassiveTransport) submitToHost(host string, op *goruntime.ClientOperation) activePassiveSubmitResult {
+	endpoint, ok := t.endpoints[host]
+	if !ok {
+		return activePassiveSubmitResult{
+			state: activePassiveSubmitLocalError,
+			err:   fmt.Errorf("%w: %s", ErrActivePassiveUnknownHost, host),
+		}
+	}
+
+	req, err := endpoint.runtime.CreateHttpRequest(op)
+	if err != nil {
+		return activePassiveSubmitResult{
+			state: activePassiveSubmitLocalError,
+			err:   err,
+		}
+	}
+
+	ctx, cancel := requestContext(endpoint.runtime.Context, op.Context, operationTimeout(op.Params))
+	defer cancel()
+
+	resp, err := effectiveHTTPClient(op.Client, endpoint.httpClient).Do(req.WithContext(ctx))
+	if err != nil {
+		return activePassiveSubmitResult{
+			state: activePassiveSubmitUnrecognizableError,
+			err:   err,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTemporaryRedirect {
+		return activePassiveSubmitResult{
+			state: activePassiveSubmitSwitchSignal,
+			err:   goruntime.NewAPIError("active-passive switch signal", activePassiveHTTPResponse{response: resp}, resp.StatusCode),
+		}
+	}
+
+	if op.Reader == nil {
+		return activePassiveSubmitResult{
+			state: activePassiveSubmitLocalError,
+			err:   errActivePassiveNoResponseReader,
+		}
+	}
+
+	consumer, err := responseConsumer(endpoint.runtime, resp)
+	if err != nil {
+		return activePassiveSubmitResult{
+			state: activePassiveSubmitUnrecognizableError,
+			err:   err,
+		}
+	}
+
+	result, err := op.Reader.ReadResponse(activePassiveHTTPResponse{response: resp}, consumer)
+	if err == nil {
+		return activePassiveSubmitResult{
+			state:  activePassiveSubmitSuccess,
+			result: result,
+		}
+	}
+
+	if isUnrecognizableResponseError(err) {
+		return activePassiveSubmitResult{
+			state: activePassiveSubmitUnrecognizableError,
+			err:   err,
+		}
+	}
+
+	return activePassiveSubmitResult{
+		state: activePassiveSubmitRecognizableError,
+		err:   err,
+	}
+}
+
+func (t *ActivePassiveTransport) clearCurrentActiveHostIf(host string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.currentActiveHost == host {
+		t.currentActiveHost = ""
+	}
+}
+
+func (t *ActivePassiveTransport) clearCurrentActiveHost() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.currentActiveHost = ""
+}
+
+func cloneNoRedirectHTTPClient(base *http.Client) *http.Client {
+	if base == nil {
+		return &http.Client{CheckRedirect: stopRedirect}
+	}
+
+	cloned := *base
+	cloned.CheckRedirect = stopRedirect
+	return &cloned
+}
+
+func stopRedirect(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
+}
+
+func effectiveHTTPClient(opClient *http.Client, fallback *http.Client) *http.Client {
+	if opClient == nil {
+		return fallback
+	}
+	return cloneNoRedirectHTTPClient(opClient)
+}
+
+func requestContext(runtimeCtx, opCtx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if opCtx != nil {
+		return context.WithCancel(opCtx)
+	}
+
+	parent := runtimeCtx
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	if timeout <= 0 {
+		return context.WithCancel(parent)
+	}
+
+	return context.WithTimeout(parent, timeout)
+}
+
+func defaultContext(ctx context.Context) context.Context {
+	if ctx != nil {
+		return ctx
+	}
+	return context.Background()
+}
+
+func operationTimeout(params goruntime.ClientRequestWriter) time.Duration {
+	if params == nil {
+		return httptransport.DefaultTimeout
+	}
+
+	value := reflect.ValueOf(params)
+	if value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return httptransport.DefaultTimeout
+		}
+		value = value.Elem()
+	}
+	if value.Kind() != reflect.Struct {
+		return httptransport.DefaultTimeout
+	}
+
+	timeoutField := value.FieldByName("timeout")
+	if !timeoutField.IsValid() || timeoutField.Kind() != reflect.Int64 {
+		return httptransport.DefaultTimeout
+	}
+
+	timeout := time.Duration(timeoutField.Int())
+	if timeout <= 0 {
+		return httptransport.DefaultTimeout
+	}
+
+	return timeout
+}
+
+func responseConsumer(runtime *httptransport.Runtime, resp *http.Response) (goruntime.Consumer, error) {
+	contentType := resp.Header.Get(goruntime.HeaderContentType)
+	if contentType == "" {
+		contentType = runtime.DefaultMediaType
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, fmt.Errorf("parse content type: %w", err)
+	}
+
+	consumer, ok := runtime.Consumers[mediaType]
+	if ok {
+		return consumer, nil
+	}
+
+	consumer, ok = runtime.Consumers[goruntime.DefaultMime]
+	if ok {
+		return consumer, nil
+	}
+
+	return nil, fmt.Errorf("no consumer for %q", contentType)
+}
+
+func isUnrecognizableResponseError(err error) bool {
+	var apiErr *goruntime.APIError
+	if errors.As(err, &apiErr) {
+		return true
+	}
+
+	var unexpectedErr *models.UnexpectedError
+	return errors.As(err, &unexpectedErr)
+}
+
+func waitForDiscover(ctx context.Context, wait chan struct{}) error {
+	if ctx == nil {
+		<-wait
+		return nil
+	}
+
+	select {
+	case <-wait:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/client/active_passive_client_always_probe_strategy_test.go
+++ b/client/active_passive_client_always_probe_strategy_test.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestAlwaysProbeStrategyProbesBeforeEveryRequest(t *testing.T) {
+	var probeCount int32
+	var requestCount int32
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&probeCount, 1)
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			atomic.AddInt32(&requestCount, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("active"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer active.Close()
+
+	transport := newTestActivePassiveTransportWithStrategy(t, FailoverStrategyAlwaysProbe, active.URL)
+
+	for i := 0; i < 2; i++ {
+		result, err := transport.Submit(testActivePassiveOperation())
+		if err != nil {
+			t.Fatalf("Submit(%d) error = %v", i, err)
+		}
+		if result != "active" {
+			t.Fatalf("Submit(%d) result = %v, want active", i, result)
+		}
+	}
+
+	host := testServerHost(t, active.URL)
+	if got := transport.CurrentActiveHost(); got != host {
+		t.Fatalf("CurrentActiveHost() = %q, want %q", got, host)
+	}
+	if got := atomic.LoadInt32(&probeCount); got != 2 {
+		t.Fatalf("probe count = %d, want 2", got)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 2 {
+		t.Fatalf("request count = %d, want 2", got)
+	}
+}
+
+func TestAlwaysProbeStrategyReturnsSignalOn307AfterFreshProbe(t *testing.T) {
+	var probeCount int32
+	var requestCount int32
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&probeCount, 1)
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			atomic.AddInt32(&requestCount, 1)
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer active.Close()
+
+	transport := newTestActivePassiveTransportWithStrategy(t, FailoverStrategyAlwaysProbe, active.URL)
+
+	_, err := transport.Submit(testActivePassiveOperation())
+	if !errors.Is(err, ErrActivePassiveFailoverRequired) {
+		t.Fatalf("Submit() error = %v, want ErrActivePassiveFailoverRequired", err)
+	}
+	if got := transport.CurrentActiveHost(); got != "" {
+		t.Fatalf("CurrentActiveHost() = %q, want empty", got)
+	}
+	if got := atomic.LoadInt32(&probeCount); got != 1 {
+		t.Fatalf("probe count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+}

--- a/client/active_passive_client_default_strategy_test.go
+++ b/client/active_passive_client_default_strategy_test.go
@@ -1,0 +1,248 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDefaultFailoverStrategyDiscoversAndCachesPreferredAddress(t *testing.T) {
+	var passiveProbeCount int32
+	var passiveRequestCount int32
+	passive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&passiveProbeCount, 1)
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		case "/test":
+			atomic.AddInt32(&passiveRequestCount, 1)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer passive.Close()
+
+	var activeProbeCount int32
+	var activeRequestCount int32
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&activeProbeCount, 1)
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			atomic.AddInt32(&activeRequestCount, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("active"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer active.Close()
+
+	transport := newTestActivePassiveTransport(t, passive.URL, active.URL)
+
+	result, err := transport.Submit(testActivePassiveOperation())
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if result != "active" {
+		t.Fatalf("Submit() result = %v, want active", result)
+	}
+
+	activeHost := testServerHost(t, active.URL)
+	if got := transport.CurrentActiveHost(); got != activeHost {
+		t.Fatalf("CurrentActiveHost() = %q, want %q", got, activeHost)
+	}
+
+	result, err = transport.Submit(testActivePassiveOperation())
+	if err != nil {
+		t.Fatalf("second Submit() error = %v", err)
+	}
+	if result != "active" {
+		t.Fatalf("second Submit() result = %v, want active", result)
+	}
+	if got := atomic.LoadInt32(&passiveProbeCount); got != 1 {
+		t.Fatalf("passive probe count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&activeProbeCount); got != 1 {
+		t.Fatalf("active probe count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&passiveRequestCount); got != 0 {
+		t.Fatalf("passive request count = %d, want 0", got)
+	}
+	if got := atomic.LoadInt32(&activeRequestCount); got != 2 {
+		t.Fatalf("active request count = %d, want 2", got)
+	}
+}
+
+func TestDefaultFailoverStrategyKeepsPreferredAddressOnRecognizableError(t *testing.T) {
+	var probeCount int32
+	var requestCount int32
+	statusCode := int32(http.StatusBadRequest)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&probeCount, 1)
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			atomic.AddInt32(&requestCount, 1)
+			w.WriteHeader(int(atomic.LoadInt32(&statusCode)))
+			_, _ = w.Write([]byte("active"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	transport := newTestActivePassiveTransport(t, server.URL)
+
+	_, err := transport.Submit(testActivePassiveOperation())
+	if !errors.Is(err, errActivePassiveTestRecognizable) {
+		t.Fatalf("Submit() error = %v, want recognizable error", err)
+	}
+
+	host := testServerHost(t, server.URL)
+	if got := transport.CurrentActiveHost(); got != host {
+		t.Fatalf("CurrentActiveHost() = %q, want %q", got, host)
+	}
+
+	atomic.StoreInt32(&statusCode, http.StatusOK)
+	result, err := transport.Submit(testActivePassiveOperation())
+	if err != nil {
+		t.Fatalf("second Submit() error = %v", err)
+	}
+	if result != "active" {
+		t.Fatalf("second Submit() result = %v, want active", result)
+	}
+	if got := atomic.LoadInt32(&probeCount); got != 1 {
+		t.Fatalf("probe count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 2 {
+		t.Fatalf("request count = %d, want 2", got)
+	}
+}
+
+func TestDefaultFailoverStrategyReprobesAndRetriesOnceOn307(t *testing.T) {
+	var staleRequestCount int32
+	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		case "/test":
+			atomic.AddInt32(&staleRequestCount, 1)
+			w.Header().Set("Location", "/ignored")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer stale.Close()
+
+	var activeProbeCount int32
+	var activeRequestCount int32
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&activeProbeCount, 1)
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			atomic.AddInt32(&activeRequestCount, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("active"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer active.Close()
+
+	transport := newTestActivePassiveTransport(t, stale.URL, active.URL)
+	setTestCurrentActiveHost(transport, testServerHost(t, stale.URL))
+
+	result, err := transport.Submit(testActivePassiveOperation())
+	if err != nil {
+		t.Fatalf("Submit() error = %v", err)
+	}
+	if result != "active" {
+		t.Fatalf("Submit() result = %v, want active", result)
+	}
+
+	activeHost := testServerHost(t, active.URL)
+	if got := transport.CurrentActiveHost(); got != activeHost {
+		t.Fatalf("CurrentActiveHost() = %q, want %q", got, activeHost)
+	}
+	if got := atomic.LoadInt32(&staleRequestCount); got != 1 {
+		t.Fatalf("stale request count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&activeProbeCount); got != 1 {
+		t.Fatalf("active probe count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&activeRequestCount); got != 1 {
+		t.Fatalf("active request count = %d, want 1", got)
+	}
+}
+
+func TestDefaultFailoverStrategyClearsPreferredAddressOnUnrecognizableError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			w.WriteHeader(http.StatusTeapot)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	transport := newTestActivePassiveTransport(t, server.URL)
+
+	_, err := transport.Submit(testActivePassiveOperation())
+	if err == nil {
+		t.Fatal("Submit() error = nil, want unrecognizable error")
+	}
+	if got := transport.CurrentActiveHost(); got != "" {
+		t.Fatalf("CurrentActiveHost() = %q, want empty", got)
+	}
+}
+
+func TestDefaultFailoverStrategyReturnsRetryExhaustedAfterSecond307(t *testing.T) {
+	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		case "/test":
+			w.Header().Set("Location", "/ignored")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer stale.Close()
+
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			w.Header().Set("Location", "/ignored")
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer active.Close()
+
+	transport := newTestActivePassiveTransport(t, stale.URL, active.URL)
+	setTestCurrentActiveHost(transport, testServerHost(t, stale.URL))
+
+	_, err := transport.Submit(testActivePassiveOperation())
+	if !errors.Is(err, ErrActivePassiveRetryExhausted) {
+		t.Fatalf("Submit() error = %v, want ErrActivePassiveRetryExhausted", err)
+	}
+	if got := transport.CurrentActiveHost(); got != "" {
+		t.Fatalf("CurrentActiveHost() = %q, want empty", got)
+	}
+}

--- a/client/active_passive_client_manual_failover_strategy_test.go
+++ b/client/active_passive_client_manual_failover_strategy_test.go
@@ -1,0 +1,67 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestManualFailoverStrategyReturnsSignalWithoutRediscoveryOn307(t *testing.T) {
+	var staleProbeCount int32
+	var staleRequestCount int32
+	stale := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&staleProbeCount, 1)
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		case "/test":
+			atomic.AddInt32(&staleRequestCount, 1)
+			w.WriteHeader(http.StatusTemporaryRedirect)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer stale.Close()
+
+	var activeProbeCount int32
+	var activeRequestCount int32
+	active := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			atomic.AddInt32(&activeProbeCount, 1)
+			w.WriteHeader(http.StatusOK)
+		case "/test":
+			atomic.AddInt32(&activeRequestCount, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("active"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer active.Close()
+
+	transport := newTestActivePassiveTransportWithStrategy(t, FailoverStrategyManualFailover, stale.URL, active.URL)
+	setTestCurrentActiveHost(transport, testServerHost(t, stale.URL))
+
+	_, err := transport.Submit(testActivePassiveOperation())
+	if !errors.Is(err, ErrActivePassiveFailoverRequired) {
+		t.Fatalf("Submit() error = %v, want ErrActivePassiveFailoverRequired", err)
+	}
+	if got := transport.CurrentActiveHost(); got != "" {
+		t.Fatalf("CurrentActiveHost() = %q, want empty", got)
+	}
+	if got := atomic.LoadInt32(&staleProbeCount); got != 0 {
+		t.Fatalf("stale probe count = %d, want 0", got)
+	}
+	if got := atomic.LoadInt32(&staleRequestCount); got != 1 {
+		t.Fatalf("stale request count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&activeProbeCount); got != 0 {
+		t.Fatalf("active probe count = %d, want 0", got)
+	}
+	if got := atomic.LoadInt32(&activeRequestCount); got != 0 {
+		t.Fatalf("active request count = %d, want 0", got)
+	}
+}

--- a/client/active_passive_client_test.go
+++ b/client/active_passive_client_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
@@ -34,6 +35,38 @@ func newTestActivePassiveTransport(t *testing.T, serverURLs ...string) *ActivePa
 	}
 
 	return transport
+}
+
+func TestActivePassiveProbeUsesConfiguredHTTPClientTLS(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/healthz":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	host := testServerHost(t, server.URL)
+	transport, err := newActivePassiveTransport(ActivePassiveClientConfig{
+		Endpoints:    []string{host},
+		BasePath:     "/v2/api",
+		Schemes:      []string{"https"},
+		ProbeTimeout: time.Second,
+		HTTPClient:   server.Client(),
+	}, strfmt.Default)
+	if err != nil {
+		t.Fatalf("newActivePassiveTransport() error = %v", err)
+	}
+
+	activeHost, err := transport.ensureActiveHost(context.Background())
+	if err != nil {
+		t.Fatalf("ensureActiveHost() error = %v", err)
+	}
+	if activeHost != host {
+		t.Fatalf("ensureActiveHost() = %q, want %q", activeHost, host)
+	}
 }
 
 func newTestActivePassiveTransportWithStrategy(t *testing.T, strategy FailoverStrategy, serverURLs ...string) *ActivePassiveTransport {

--- a/client/active_passive_client_test.go
+++ b/client/active_passive_client_test.go
@@ -1,0 +1,103 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	goruntime "github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+)
+
+var errActivePassiveTestRecognizable = errors.New("recognizable api error")
+
+func newTestActivePassiveTransport(t *testing.T, serverURLs ...string) *ActivePassiveTransport {
+	t.Helper()
+
+	endpoints := make([]string, 0, len(serverURLs))
+	for _, serverURL := range serverURLs {
+		endpoints = append(endpoints, testServerHost(t, serverURL))
+	}
+
+	transport, err := newActivePassiveTransport(ActivePassiveClientConfig{
+		Endpoints:    endpoints,
+		BasePath:     "/",
+		Schemes:      []string{"http"},
+		ProbeTimeout: time.Second,
+	}, strfmt.Default)
+	if err != nil {
+		t.Fatalf("newActivePassiveTransport() error = %v", err)
+	}
+
+	return transport
+}
+
+func newTestActivePassiveTransportWithStrategy(t *testing.T, strategy FailoverStrategy, serverURLs ...string) *ActivePassiveTransport {
+	t.Helper()
+
+	endpoints := make([]string, 0, len(serverURLs))
+	for _, serverURL := range serverURLs {
+		endpoints = append(endpoints, testServerHost(t, serverURL))
+	}
+
+	transport, err := newActivePassiveTransport(ActivePassiveClientConfig{
+		Endpoints:        endpoints,
+		BasePath:         "/",
+		Schemes:          []string{"http"},
+		ProbeTimeout:     time.Second,
+		FailoverStrategy: strategy,
+	}, strfmt.Default)
+	if err != nil {
+		t.Fatalf("newActivePassiveTransport() error = %v", err)
+	}
+
+	return transport
+}
+
+func testActivePassiveOperation() *goruntime.ClientOperation {
+	return &goruntime.ClientOperation{
+		ID:                 "test-active-passive",
+		Method:             http.MethodGet,
+		PathPattern:        "/test",
+		ProducesMediaTypes: []string{goruntime.JSONMime},
+		Params: goruntime.ClientRequestWriterFunc(func(goruntime.ClientRequest, strfmt.Registry) error {
+			return nil
+		}),
+		Reader: goruntime.ClientResponseReaderFunc(func(response goruntime.ClientResponse, consumer goruntime.Consumer) (interface{}, error) {
+			switch response.Code() {
+			case http.StatusOK:
+				body, err := ioutil.ReadAll(response.Body())
+				if err != nil {
+					return nil, err
+				}
+				return string(body), nil
+			case http.StatusBadRequest:
+				return nil, errActivePassiveTestRecognizable
+			default:
+				return nil, goruntime.NewAPIError("test active-passive", response, response.Code())
+			}
+		}),
+		Context: context.Background(),
+	}
+}
+
+func testServerHost(t *testing.T, serverURL string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("parse server URL %q: %v", serverURL, err)
+	}
+
+	return parsed.Host
+}
+
+func setTestCurrentActiveHost(transport *ActivePassiveTransport, host string) {
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	transport.currentActiveHost = host
+}

--- a/client/login_client.go
+++ b/client/login_client.go
@@ -79,26 +79,36 @@ func NewWithUserConfig(clientConfig ClientConfig, userConfig UserConfig) (*Cloud
 	} else {
 		client = New(transport, *clientConfig.formats)
 	}
-	var configId string
-	if userConfig.Source == models.UserSourceLDAP {
-		// try get auth stategies to replace legacy ldap login source
-		straetgyMap := getAuthConfigs(fmt.Sprintf("http://%s/api", clientConfig.Host))
-		configId = straetgyMap["LDAP"]
+	if err := loginWithUserConfig(client, clientConfig.Host, userConfig); err != nil {
+		return nil, err
 	}
+	return client, nil
+}
+
+func loginWithUserConfig(client *Cloudtower, authConfigHost string, userConfig UserConfig) error {
+	var configID string
+	if userConfig.Source == models.UserSourceLDAP {
+		// Try get auth strategies to replace legacy ldap login source.
+		strategyMap := getAuthConfigs(fmt.Sprintf("http://%s/api", authConfigHost))
+		configID = strategyMap["LDAP"]
+	}
+
 	params := user.NewLoginParams()
 	params.RequestBody = &models.LoginInput{
 		Username: &userConfig.Name,
 		Password: &userConfig.Password,
 		Source:   userConfig.Source.Pointer(),
 	}
-	if configId != "" {
-		params.RequestBody.AuthConfigID = &configId
+	if configID != "" {
+		params.RequestBody.AuthConfigID = &configID
 		params.RequestBody.Source = models.UserSourceAUTHN.Pointer()
 	}
+
 	resp, err := client.User.Login(params)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	transport.DefaultAuthentication = httptransport.APIKeyAuth("Authorization", "header", *resp.Payload.Data.Token)
-	return client, nil
+
+	client.SetDefaultAuthentication(httptransport.APIKeyAuth("Authorization", "header", *resp.Payload.Data.Token))
+	return nil
 }

--- a/client/rest_client.go
+++ b/client/rest_client.go
@@ -6,6 +6,10 @@ package client
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
@@ -749,4 +753,66 @@ func (c *Cloudtower) SetTransport(transport runtime.ClientTransport) {
 	c.WitnessService.SetTransport(transport)
 	c.Zone.SetTransport(transport)
 	c.ZoneTopo.SetTransport(transport)
+}
+
+// ProbeActivePassive probes the current endpoint and reports whether it is active.
+// It sends a GET request to /api/healthz on the endpoint base URL.
+// 200 means active, 307 means passive, and any other result is treated as an error.
+func (c *Cloudtower) ProbeActivePassive(ctx context.Context) (bool, error) {
+	transport, ok := c.Transport.(*httptransport.Runtime)
+	if !ok {
+		return false, fmt.Errorf("unsupported transport type for ProbeActivePassive: %T", c.Transport)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if transport.Host == "" {
+		return false, fmt.Errorf("probe active-passive missing host")
+	}
+
+	op := &runtime.ClientOperation{
+		ID:                 "probe-active-passive",
+		Method:             http.MethodGet,
+		PathPattern:        "/api/healthz",
+		ProducesMediaTypes: []string{runtime.JSONMime},
+		Params: runtime.ClientRequestWriterFunc(func(runtime.ClientRequest, strfmt.Registry) error {
+			return nil
+		}),
+		Reader: runtime.ClientResponseReaderFunc(func(runtime.ClientResponse, runtime.Consumer) (interface{}, error) {
+			return nil, nil
+		}),
+		Context: ctx,
+	}
+
+	req, err := transport.CreateHttpRequest(op)
+	if err != nil {
+		return false, err
+	}
+
+	httpClient := &http.Client{
+		Transport: transport.Transport,
+		Jar:       transport.Jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	if httpClient.Transport == nil {
+		httpClient.Transport = http.DefaultTransport
+	}
+
+	resp, err := httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusTemporaryRedirect:
+		return false, nil
+	default:
+		return false, runtime.NewAPIError("probe active-passive returned unexpected status", activePassiveHTTPResponse{response: resp}, resp.StatusCode)
+	}
 }


### PR DESCRIPTION
## 
 实现一个 active_passive_client，业务逻辑如下所示：

- 创建时，显式指定多个（目前最多两个，不过设计时应当考虑一主多备）地址，不区分注册时的主备
- 定义一个 preferred_address 属性，表示为首选的地址，默认为 nil
- 支持配置策略：默认、AlwaysProbe、ManualFailover
- 对于默认策略每次请求时：
  1. 进入请求
     - preferred_address != nil：使用 preferred_address 发送请求。
     - preferred_address == nil：进入探活。
  2. 探活
     - 按注册顺序请求每个地址的 /api/healthz。
     - 第一个返回 200 的地址：设置为 preferred_address，用它发送本次请求。
     - 没有任何地址返回 200：返回“无可用 active 地址”错误。
  3. 请求返回
     - 成功响应：返回结果，保留 preferred_address。
     - 可识别业务错误：返回该错误，保留 preferred_address。
     - 307：清空 preferred_address，重新进入探活；探活成功后重发本次请求。
     - 不可识别错误：清空 preferred_address，返回该错误。
  4. 307 后重试返回
     - 成功响应：返回结果，保留新的 preferred_address。
     - 可识别业务错误：返回该错误，保留新的 preferred_address。
     - 307：清空 preferred_address，返回重试耗尽错误。
     - 不可识别错误：清空 preferred_address，返回该错误。

对于 AlwaysProbe，每次请求时都会探活
对于 ManualFailover，不会手动处理 307，交给下游处理

## 自测代码：

```
package main

import (
	"context"
	"fmt"
	"log"

	apiclient "github.com/smartxworks/cloudtower-go-sdk/v2/client"
	"github.com/smartxworks/cloudtower-go-sdk/v2/client/vm"
	"github.com/smartxworks/cloudtower-go-sdk/v2/models"
)

func main() {
	client, err := apiclient.NewActivePassiveClient(context.Background(), apiclient.ActivePassiveClientConfig{
		Endpoints: []string{
			"172.21.152.75",
			"172.21.152.95",
		},
		BasePath: "/v2/api",
		Schemes:  []string{"http"},
		UserConfig: &apiclient.UserConfig{
			Name:     "admin",
			Password: "admin",
			Source:   models.UserSourceLOCAL,
		},
	})
	if err != nil {
		log.Fatalf("create active-passive client: %v", err)
	}

	host := client.CurrentActiveHost()
	fmt.Printf("current active host=%s\n", host)

	params := vm.NewGetVmsParams()
	params.RequestBody = &models.GetVmsRequestBody{
		First: int32Ptr(10),
	}

	resp, err := client.VM.GetVms(params)
	if err != nil {
		log.Fatalf("get vms failed: %v", err)
	}

	for _, vm := range resp.Payload {
		fmt.Printf("vm: id=%s, name=%s\n", *vm.ID, *vm.Name)
	}

}

func int32Ptr(v int32) *int32 {
	return &v
}

```

可以正常访问主：

<img width="1171" height="467" alt="image" src="https://github.com/user-attachments/assets/73b60302-d96d-4a1f-bb41-edd804d37655" />


ha 后执行，正常访问主

<img width="1183" height="466" alt="image" src="https://github.com/user-attachments/assets/7593e0da-49eb-44ba-a00e-09961d851979" />

修改代码，使其定时执行：

```
go run main.go
2026-04-28T18:50:41+08:00 request success active_ip=172.21.152.95
2026/04/28 18:50:51 request failed active_ip= error=active-passive discover found no active host
2026/04/28 18:51:01 request failed active_ip= error=active-passive discover found no active host
2026/04/28 18:51:11 request failed active_ip= error=active-passive discover found no active host
2026/04/28 18:51:21 request failed active_ip= error=active-passive discover found no active host: 172.21.152.75: probe active-passive returned unexpected status (status 502): {}
2026/04/28 18:51:37 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 502): {}
2026/04/28 18:51:42 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 502): {}
2026/04/28 18:51:52 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 502): {}
2026/04/28 18:52:02 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 403): {}
2026/04/28 18:52:11 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 403): {}
2026/04/28 18:52:21 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 403): {}
2026/04/28 18:52:31 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 403): {}
2026/04/28 18:52:41 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 403): {}
2026/04/28 18:52:51 request failed active_ip= error=response status code does not match any response statuses defined for this endpoint in the swagger spec (status 403): {}
2026-04-28T18:53:03+08:00 request success active_ip=172.21.152.75
```

